### PR TITLE
If a tag has the same name as a non-meta puzzle, let it be removed

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -194,6 +194,27 @@ class ApiTests(CardboardTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(puzzle.tags.count(), 0)
 
+    def test_can_delete_same_name_tag(self):
+        self.create_puzzle({"name": "test name", "url": TEST_URL})
+        puzzle = Puzzle.objects.get()
+        self.create_tag(puzzle.pk, {"name": "test name", "color": PuzzleTag.BLUE})
+        self.assertEqual(puzzle.tags.count(), 1)
+        tag = puzzle.tags.get()
+
+        response = self.delete_tag(puzzle.pk, tag.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(puzzle.tags.count(), 0)
+
+    def test_cannot_delete_meta_tag(self):
+        self.create_puzzle({"name": "test name", "url": TEST_URL, "is_meta": True})
+        puzzle = Puzzle.objects.get()
+        self.assertEqual(puzzle.tags.count(), 1)
+        tag = puzzle.tags.get()
+
+        response = self.delete_tag(puzzle.pk, tag.pk)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(puzzle.tags.count(), 1)
+
     def test_opposing_tags(self):
         self.create_puzzle({"name": "test name", "url": TEST_URL})
         puzzle = Puzzle.objects.get()

--- a/api/views.py
+++ b/api/views.py
@@ -298,7 +298,7 @@ class PuzzleTagViewSet(viewsets.ModelViewSet):
         with transaction.atomic():
             tag = self.get_object()
             puzzle = get_object_or_404(Puzzle, pk=self.kwargs["puzzle_id"])
-            if puzzle.name == tag.name:
+            if puzzle.name == tag.name and tag.is_meta:
                 return Response(
                     {
                         "detail": "You cannot remove a meta's tag (%s) from itself"


### PR DESCRIPTION
Fixes #497