### PR TITLE
Query whitelisted emails at authentication time (fixes #500)

### DIFF
--- a/cardboard/settings.py
+++ b/cardboard/settings.py
@@ -249,18 +249,16 @@ except KeyError as e:
     )
 
 SOCIAL_AUTH_PIPELINE = (
-    'social_core.pipeline.social_auth.social_details',
-    'social_core.pipeline.social_auth.social_uid',
-
+    "social_core.pipeline.social_auth.social_details",
+    "social_core.pipeline.social_auth.social_uid",
     # custom auth_allowed check in lieu of default one
-    'google_api_lib.sync_tasks.auth_allowed',
-
-    'social_core.pipeline.social_auth.social_user',
-    'social_core.pipeline.user.get_username',
-    'social_core.pipeline.user.create_user',
-    'social_core.pipeline.social_auth.associate_user',
-    'social_core.pipeline.social_auth.load_extra_data',
-    'social_core.pipeline.user.user_details',
+    "google_api_lib.sync_tasks.auth_allowed",
+    "social_core.pipeline.social_auth.social_user",
+    "social_core.pipeline.user.get_username",
+    "social_core.pipeline.user.create_user",
+    "social_core.pipeline.social_auth.associate_user",
+    "social_core.pipeline.social_auth.load_extra_data",
+    "social_core.pipeline.user.user_details",
 )
 
 # Taggit Overrides

--- a/google_api_lib/sync_tasks.py
+++ b/google_api_lib/sync_tasks.py
@@ -17,10 +17,12 @@ def auth_allowed(backend, details, response, *args, **kwargs):
     is in the list of emails added to the Google Drive folder.
     Part of the SOCIAL_AUTH_PIPELINE (see settings.py).
     """
-    email = details.get('email').lower()
+    email = details.get("email").lower()
     # allow all emails if Google Drive integration is not set up
     # otherwise, only allow emails added to Google Drive folder
-    if settings.GOOGLE_API_AUTHN_INFO and email not in get_file_user_emails(settings.GOOGLE_DRIVE_HUNT_FOLDER_ID):
+    if settings.GOOGLE_API_AUTHN_INFO and email not in get_file_user_emails(
+        settings.GOOGLE_DRIVE_HUNT_FOLDER_ID
+    ):
         raise AuthForbidden(backend)
 
 

--- a/new-hunt-setup.md
+++ b/new-hunt-setup.md
@@ -88,4 +88,4 @@ Miscellaneous configs:
 
 ### Giving a new user access to Cardboard
 
-The authorized users for a Cardboard deployment are the Google users who have access to the Google Drive folder for the hunt (configured by the `GOOGLE_DRIVE_HUNT_FOLDER_ID` variable). To give a new user access, share the Google Drive folder with that user, and then restart Cardboard using `heroku restart` or from the web UI. The ability to add users without having to restart Heroku will be addressed in [#500](https://github.com/cardinalitypuzzles/cardboard/issues/500).
+The authorized users for a Cardboard deployment are the Google users who have access to the Google Drive folder for the hunt (configured by the `GOOGLE_DRIVE_HUNT_FOLDER_ID` variable). To give a new user access, simply share the Google Drive folder with that user.


### PR DESCRIPTION
Before, the list of whitelisted emails was only calculated once at start-up time, and every time you added a user, you would need to restart Cardboard before that user could log in.

Now we just query the list of emails added to the Google Drive as part of the authentication flow. So as soon as you add a user to a Google Drive, they should be able to login to Cardboard.

The Google Drive API to get the folder permissions is pretty fast, so it doesn't noticeably slow down the login. Also, according to https://support.google.com/a/answer/10445916?hl=en, the default Drive API quota is 10,000 calls every 100 seconds, which is plenty for us.

My implementation of `auth_allowed` is based off the default `auth_allowed` implementation here:
* https://github.com/python-social-auth/social-core/blob/911957bc2c0cf0f2e3419e1f1e7caaf25059dc6d/social_core/pipeline/social_auth.py#L12-L14
* https://github.com/python-social-auth/social-core/blob/911957bc2c0cf0f2e3419e1f1e7caaf25059dc6d/social_core/backends/base.py#L148-L159