### PR TITLE
iss #452: Update default tag list

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The default status of a new puzzle is SOLVING. When an answer is submitted, the 
 
 Users can also tag puzzles as belonging to one or more metas, mark puzzles as high priority or low priority, logic or word puzzles, backsolved, or create new tags by clicking the "+" icon in the "Tags" column.
 
-<img src='https://user-images.githubusercontent.com/544734/71759748-cfc8f780-2e7f-11ea-948d-1d0f32593089.png' width='300'>
+<img src='https://user-images.githubusercontent.com/1312469/147144787-554aac39-3558-47c7-af75-2e7c89f1d599.png' width='300'>
 
 Clicking the "x" icon next to an existing tag will remove it from the puzzle.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The default status of a new puzzle is SOLVING. When an answer is submitted, the 
 
 Users can also tag puzzles as belonging to one or more metas, mark puzzles as high priority or low priority, logic or word puzzles, backsolved, or create new tags by clicking the "+" icon in the "Tags" column.
 
-<img src='https://user-images.githubusercontent.com/1312469/147144787-554aac39-3558-47c7-af75-2e7c89f1d599.png' width='300'>
+<img src='https://user-images.githubusercontent.com/1312469/147148090-9937c4a2-58f4-4098-b496-4ff9dc07891f.png' width='300'>
 
 Clicking the "x" icon next to an existing tag will remove it from the puzzle.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The default status of a new puzzle is SOLVING. When an answer is submitted, the 
 
 Users can also tag puzzles as belonging to one or more metas, mark puzzles as high priority or low priority, logic or word puzzles, backsolved, or create new tags by clicking the "+" icon in the "Tags" column.
 
-<img src='https://user-images.githubusercontent.com/1312469/147148090-9937c4a2-58f4-4098-b496-4ff9dc07891f.png' width='300'>
+<img src='https://user-images.githubusercontent.com/1312469/147149416-29dda7c5-bde5-4277-8866-9b9954980bcd.png' width='300'>
 
 Clicking the "x" icon next to an existing tag will remove it from the puzzle.
 

--- a/hunts/src/EditableTagList.js
+++ b/hunts/src/EditableTagList.js
@@ -5,6 +5,7 @@ import {
   deletePuzzleTag,
   selectPuzzleById,
 } from "./puzzlesSlice";
+import { SELECTABLE_TAG_COLORS } from "./constants";
 import TagPill from "./TagPill";
 
 function EditableTagList({ puzzleId, tags }) {
@@ -15,37 +16,59 @@ function EditableTagList({ puzzleId, tags }) {
   const puzzleTags = useSelector(selectPuzzleTags);
   const puzzleTagIds = new Set(puzzleTags.map((tag) => tag.id));
   const dispatch = useDispatch();
+
+
+  const selectable_colors = SELECTABLE_TAG_COLORS.map((tag) => tag.color)
+  const groupedTags = tags.reduce((result, item, index) => {
+    if (result.length == 0) {
+      result[0] = [item]
+    } else if (!selectable_colors.includes(item.color)) {
+      result[result.length - 1].push(item)
+    } else if (result[result.length - 1][0].color == item.color) {
+      result[result.length - 1].push(item)
+    } else {
+      result[result.length] = [item]
+    }
+
+    return result
+  }, [])
+
+
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        flexWrap: "wrap",
-      }}
-    >
-      {tags.map((tag) => (
-        <TagPill
-          {...tag}
-          puzzleId={puzzleId}
-          editable={false}
-          selected={puzzleTagIds.has(tag.id)}
-          faded={!puzzleTagIds.has(tag.id)}
-          key={tag.name}
-          onClick={() => {
-            if (puzzleTagIds.has(tag.id)) {
-              dispatch(deletePuzzleTag({ puzzleId, tagId: tag.id }));
-            } else {
-              dispatch(
-                addPuzzleTag({
-                  ...tag,
-                  puzzleId,
-                })
-              );
-            }
-          }}
-        />
-      ))}
-    </div>
+    groupedTags.map((group) => (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        {
+          group.map((tag) => (
+            <TagPill
+              {...tag}
+              puzzleId={puzzleId}
+              editable={false}
+              selected={puzzleTagIds.has(tag.id)}
+              faded={!puzzleTagIds.has(tag.id)}
+              key={tag.name}
+              onClick={() => {
+                if (puzzleTagIds.has(tag.id)) {
+                  dispatch(deletePuzzleTag({ puzzleId, tagId: tag.id }));
+                } else {
+                  dispatch(
+                    addPuzzleTag({
+                      ...tag,
+                      puzzleId,
+                    })
+                  );
+                }
+              }}
+            />
+          ))
+        }
+      </div>
+    ))
   );
 }
 

--- a/hunts/src/EditableTagList.js
+++ b/hunts/src/EditableTagList.js
@@ -17,59 +17,53 @@ function EditableTagList({ puzzleId, tags }) {
   const puzzleTagIds = new Set(puzzleTags.map((tag) => tag.id));
   const dispatch = useDispatch();
 
-
-  const selectable_colors = SELECTABLE_TAG_COLORS.map((tag) => tag.color)
+  const selectable_colors = SELECTABLE_TAG_COLORS.map((tag) => tag.color);
   const groupedTags = tags.reduce((result, item, index) => {
     if (result.length == 0) {
-      result[0] = [item]
+      result[0] = [item];
     } else if (!selectable_colors.includes(item.color)) {
-      result[result.length - 1].push(item)
+      result[result.length - 1].push(item);
     } else if (result[result.length - 1][0].color == item.color) {
-      result[result.length - 1].push(item)
+      result[result.length - 1].push(item);
     } else {
-      result[result.length] = [item]
+      result[result.length] = [item];
     }
 
-    return result
-  }, [])
+    return result;
+  }, []);
 
-
-  return (
-    groupedTags.map((group) => (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          flexWrap: "wrap",
-        }}
-      >
-        {
-          group.map((tag) => (
-            <TagPill
-              {...tag}
-              puzzleId={puzzleId}
-              editable={false}
-              selected={puzzleTagIds.has(tag.id)}
-              faded={!puzzleTagIds.has(tag.id)}
-              key={tag.name}
-              onClick={() => {
-                if (puzzleTagIds.has(tag.id)) {
-                  dispatch(deletePuzzleTag({ puzzleId, tagId: tag.id }));
-                } else {
-                  dispatch(
-                    addPuzzleTag({
-                      ...tag,
-                      puzzleId,
-                    })
-                  );
-                }
-              }}
-            />
-          ))
-        }
-      </div>
-    ))
-  );
+  return groupedTags.map((group) => (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        flexWrap: "wrap",
+      }}
+    >
+      {group.map((tag) => (
+        <TagPill
+          {...tag}
+          puzzleId={puzzleId}
+          editable={false}
+          selected={puzzleTagIds.has(tag.id)}
+          faded={!puzzleTagIds.has(tag.id)}
+          key={tag.name}
+          onClick={() => {
+            if (puzzleTagIds.has(tag.id)) {
+              dispatch(deletePuzzleTag({ puzzleId, tagId: tag.id }));
+            } else {
+              dispatch(
+                addPuzzleTag({
+                  ...tag,
+                  puzzleId,
+                })
+              );
+            }
+          }}
+        />
+      ))}
+    </div>
+  ));
 }
 
 export default EditableTagList;

--- a/hunts/src/EditableTagList.js
+++ b/hunts/src/EditableTagList.js
@@ -18,6 +18,10 @@ function EditableTagList({ puzzleId, tags }) {
   const dispatch = useDispatch();
 
   const selectable_colors = SELECTABLE_TAG_COLORS.map((tag) => tag.color);
+
+  /* Assumes that tags are given in the order they should be displayed and */
+  /* breaks them up into rows, with the first row being of the non-selectable colors */
+  /* and subsequent rows alternating between the selectable colors */
   const groupedTags = tags.reduce((result, item, index) => {
     if (result.length == 0) {
       result[0] = [item];

--- a/hunts/src/EditableTagList.js
+++ b/hunts/src/EditableTagList.js
@@ -24,13 +24,13 @@ function EditableTagList({ puzzleId, tags }) {
   /* and subsequent rows alternating between the selectable colors */
   const groupedTags = tags.reduce((result, item, index) => {
     if (result.length == 0) {
-      result[0] = [item];
+      result.push([item]);
     } else if (!selectable_colors.includes(item.color)) {
       result[result.length - 1].push(item);
     } else if (result[result.length - 1][0].color == item.color) {
       result[result.length - 1].push(item);
     } else {
-      result[result.length] = [item];
+      result.push([item]);
     }
 
     return result;

--- a/hunts/src/constants.js
+++ b/hunts/src/constants.js
@@ -15,6 +15,7 @@ export const DEFAULT_TAGS = [
 
   { name: "CROSSWORD", color: "primary" },
   { name: "CRYPTICS", color: "primary" },
+  { name: "WORDPLAY", color: "primary" },
 
   { name: "MEDIA MANIPULATION", color: "light" },
   { name: "PROGRAMMING", color: "light" },
@@ -24,7 +25,7 @@ export const DEFAULT_TAGS = [
   { name: "PHYSICS", color: "primary" },
   { name: "CHEM", color: "primary" },
   { name: "GEOGRAPHY", color: "primary" },
-  { name: "FOREIGN LANGUAGE", color: "primary" },
+  { name: "FOREIGN LANGUAGES", color: "primary" },
 
   { name: "BOOMER", color: "light" },
   { name: "ZOOMER", color: "light" },
@@ -40,6 +41,7 @@ export const DEFAULT_TAGS = [
 
   { name: "MIT", color: "primary" },
   { name: "PRINTING", color: "primary" },
+  { name: "TEAMWORK", color: "primary" },
 ];
 
 export const SHEET_REDIRECT_BASE = "/puzzles/s";

--- a/hunts/src/constants.js
+++ b/hunts/src/constants.js
@@ -1,7 +1,6 @@
 export const DEFAULT_TAG_COLOR = "primary";
 export const SELECTABLE_TAG_COLORS = [
   { color: "primary", display: "Blue" },
-  { color: "secondary", display: "Gray" },
   { color: "light", display: "White" },
 ];
 // TODO: Store these in the backend and read them from an API call
@@ -9,18 +8,38 @@ export const DEFAULT_TAGS = [
   { name: "HIGH PRIORITY", color: "danger" },
   { name: "LOW PRIORITY", color: "warning" },
   { name: "BACKSOLVED", color: "success" },
-  { name: "WORD", color: "light" },
-  { name: "CRYPTICS", color: "light" },
-  { name: "LOGIC", color: "light" },
+  { name: "SLOG", color: "secondary" },
+
+  { name: "GRID LOGIC", color: "light" },
+  { name: "NON-GRID LOGIC", color: "light" },
+
+  { name: "CROSSWORD", color: "primary" },
+  { name: "CRYPTICS", color: "primary" },
+
   { name: "MEDIA MANIPULATION", color: "light" },
   { name: "PROGRAMMING", color: "light" },
-  { name: "INTERACTIVE", color: "light" },
-  { name: "MATH", color: "light" },
-  { name: "PRINTING", color: "light" },
-  { name: "TRIVIA", color: "light" },
-  { name: "MIT", color: "light" },
-  { name: "SLOG", color: "secondary" },
-  { name: "INTERACTIVE", color: "primary" },
+
+  { name: "MATH", color: "primary" },
+  { name: "BIO", color: "primary" },
+  { name: "PHYSICS", color: "primary" },
+  { name: "CHEM", color: "primary" },
+  { name: "GEOGRAPHY", color: "primary" },
+  { name: "FOREIGN LANGUAGE", color: "primary" },
+
+  { name: "BOOMER", color: "light" },
+  { name: "ZOOMER", color: "light" },
+  { name: "MUSIC ID", color: "light" },
+  { name: "ART ID", color: "light" },
+  { name: "MOVIE", color: "light" },
+  { name: "TV", color: "light" },
+  { name: "ANIME", color: "light" },
+  { name: "VIDEO GAMES", color: "light" },
+  { name: "BOARD GAMES", color: "light" },
+  { name: "SPORTS", color: "light" },
+  { name: "KNITTING", color: "light" },
+
+  { name: "MIT", color: "primary" },
+  { name: "PRINTING", color: "primary" },
 ];
 
 export const SHEET_REDIRECT_BASE = "/puzzles/s";

--- a/hunts/src/constants.js
+++ b/hunts/src/constants.js
@@ -25,6 +25,7 @@ export const DEFAULT_TAGS = [
   { name: "PHYSICS", color: "primary" },
   { name: "CHEM", color: "primary" },
   { name: "GEOGRAPHY", color: "primary" },
+  { name: "LITERATURE", color: "primary" },
   { name: "FOREIGN LANGUAGES", color: "primary" },
 
   { name: "BOOMER", color: "light" },

--- a/hunts/src/constants.js
+++ b/hunts/src/constants.js
@@ -3,7 +3,7 @@ export const SELECTABLE_TAG_COLORS = [
   { color: "primary", display: "Blue" },
   { color: "light", display: "White" },
 ];
-// TODO: Store these in the backend and read them from an API call
+// TODO(#527): Store these in the backend and read them from an API call
 export const DEFAULT_TAGS = [
   { name: "HIGH PRIORITY", color: "danger" },
   { name: "LOW PRIORITY", color: "warning" },
@@ -28,7 +28,9 @@ export const DEFAULT_TAGS = [
   { name: "LITERATURE", color: "primary" },
   { name: "FOREIGN LANGUAGES", color: "primary" },
 
+  // older pop culture
   { name: "BOOMER", color: "light" },
+  // newer pop culture
   { name: "ZOOMER", color: "light" },
   { name: "MUSIC ID", color: "light" },
   { name: "ART ID", color: "light" },

--- a/hunts/src/puzzlesSlice.js
+++ b/hunts/src/puzzlesSlice.js
@@ -6,7 +6,7 @@ import {
 } from "@reduxjs/toolkit";
 import { selectHuntId } from "./huntSlice";
 import api from "./api";
-import { DEFAULT_TAGS, DEFAULT_TAG_ORDER } from "./constants";
+import { DEFAULT_TAGS } from "./constants";
 
 export const addPuzzle = createAsyncThunk(
   "puzzles/addPuzzle",
@@ -231,7 +231,7 @@ export const selectPuzzleTableData = createSelector(
 export const selectAllTags = createSelector(
   [puzzlesSelectors.selectAll],
   (puzzles) => {
-    // this is to get unique set of tags, choosing ones in DB if used at last once and falling back to constants if not
+    // this is to get unique set of tags, choosing ones in DB if used at least once and falling back to constants if not
     const tags = puzzles
       .map((puzzle) => puzzle.tags)
       .flat()

--- a/hunts/src/puzzlesSlice.js
+++ b/hunts/src/puzzlesSlice.js
@@ -6,7 +6,7 @@ import {
 } from "@reduxjs/toolkit";
 import { selectHuntId } from "./huntSlice";
 import api from "./api";
-import { DEFAULT_TAGS } from "./constants";
+import { DEFAULT_TAGS, DEFAULT_TAG_ORDER } from "./constants";
 
 export const addPuzzle = createAsyncThunk(
   "puzzles/addPuzzle",
@@ -231,6 +231,7 @@ export const selectPuzzleTableData = createSelector(
 export const selectAllTags = createSelector(
   [puzzlesSelectors.selectAll],
   (puzzles) => {
+    // this is to get unique set of tags, choosing ones in DB if used at last once and falling back to constants if not
     const tags = puzzles
       .map((puzzle) => puzzle.tags)
       .flat()
@@ -243,10 +244,14 @@ export const selectAllTags = createSelector(
           : tagNames.add(tag.name) && [...uniqueTags, tag],
       []
     );
-    uniqueTags.sort(
-      (a, b) => a.color.localeCompare(b.color) || a.name.localeCompare(b.name)
-    );
-    return uniqueTags;
+
+    const defaultTagNames = DEFAULT_TAGS.map((tag) => tag.name);
+    const defaultTags = uniqueTags.filter(tag => defaultTagNames.includes(tag.name))
+    const customTags = uniqueTags.filter(tag => !defaultTagNames.includes(tag.name))
+    defaultTags.sort((a, b) => defaultTagNames.indexOf(a.name) - defaultTagNames.indexOf(b.name));
+    customTags.sort((a, b) => (a.color.localeCompare(b.color) || a.name.localeCompare(b.name)));
+
+    return defaultTags.concat(customTags);
   }
 );
 

--- a/hunts/src/puzzlesSlice.js
+++ b/hunts/src/puzzlesSlice.js
@@ -231,7 +231,11 @@ export const selectPuzzleTableData = createSelector(
 export const selectAllTags = createSelector(
   [puzzlesSelectors.selectAll],
   (puzzles) => {
-    // this is to get unique set of tags, choosing ones in DB if used at least once and falling back to constants if not
+    // uniqueTags is set of unique Tags objects.
+    // After a default tag is used at least once, a Tag is created in the DB and this needs to be
+    // the version of the object in uniqueTags, instead of the dummy one created in the constants file.
+    // The DB versions are needed to display whether puzzle already has the tag.
+    // Logic below is to select the DB versions. The set is then split between default and non-default.
     const tags = puzzles
       .map((puzzle) => puzzle.tags)
       .flat()
@@ -244,7 +248,6 @@ export const selectAllTags = createSelector(
           : tagNames.add(tag.name) && [...uniqueTags, tag],
       []
     );
-
     const defaultTagNames = DEFAULT_TAGS.map((tag) => tag.name);
     const defaultTags = uniqueTags.filter((tag) =>
       defaultTagNames.includes(tag.name)

--- a/hunts/src/puzzlesSlice.js
+++ b/hunts/src/puzzlesSlice.js
@@ -246,10 +246,19 @@ export const selectAllTags = createSelector(
     );
 
     const defaultTagNames = DEFAULT_TAGS.map((tag) => tag.name);
-    const defaultTags = uniqueTags.filter(tag => defaultTagNames.includes(tag.name))
-    const customTags = uniqueTags.filter(tag => !defaultTagNames.includes(tag.name))
-    defaultTags.sort((a, b) => defaultTagNames.indexOf(a.name) - defaultTagNames.indexOf(b.name));
-    customTags.sort((a, b) => (a.color.localeCompare(b.color) || a.name.localeCompare(b.name)));
+    const defaultTags = uniqueTags.filter((tag) =>
+      defaultTagNames.includes(tag.name)
+    );
+    const customTags = uniqueTags.filter(
+      (tag) => !defaultTagNames.includes(tag.name)
+    );
+    defaultTags.sort(
+      (a, b) =>
+        defaultTagNames.indexOf(a.name) - defaultTagNames.indexOf(b.name)
+    );
+    customTags.sort(
+      (a, b) => a.color.localeCompare(b.color) || a.name.localeCompare(b.name)
+    );
 
     return defaultTags.concat(customTags);
   }


### PR DESCRIPTION
* Adds new tags
* Sorts the tags according to how the defaults list was defined in constants.js. 
* Currently, that means high pri, low pri, backsolved, and slog tags are first row and then the other tags alternate blue/white per row, roughly aligned to their subject area. The code to split the tags into rows is admittedly a little jank.

We'll want to eventually move this stuff in the DB but I sorta want to continue kicking this can down the road unless someone feels really strongly about it. 

![image](https://user-images.githubusercontent.com/1312469/147149416-29dda7c5-bde5-4277-8866-9b9954980bcd.png)