### PR TITLE
Remove the border/background around the icons

### DIFF
--- a/cardboard/static/style.css
+++ b/cardboard/static/style.css
@@ -25,7 +25,7 @@ body {
 }
 
 .table td {
-    vertical-align: baseline;
+    vertical-align: middle;
 }
 
 /* Dark/Light Mode Toggle Overrides */

--- a/hunts/src/AnswerCell.js
+++ b/hunts/src/AnswerCell.js
@@ -1,12 +1,10 @@
-import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
 import React from "react";
-import { updatePuzzle } from "./puzzlesSlice";
-import { useSelector, useDispatch } from "react-redux";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useDispatch } from "react-redux";
 import { faEdit, faTrashAlt } from "@fortawesome/free-regular-svg-icons";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { showModal } from "./modalSlice";
+import ClickableIcon from "./ClickableIcon";
 
 export default function AnswerCell({ row, value }) {
   const dispatch = useDispatch();
@@ -34,9 +32,9 @@ export default function AnswerCell({ row, value }) {
     <>
       {row.original.guesses.map(({ id, text }) => (
         <React.Fragment key={text}>
-          <span className="text-monospace">{text}</span>
-          <span
-            style={{ cursor: "pointer" }}
+          <span className="text-monospace">{text}</span>{" "}
+          <ClickableIcon
+            icon={faEdit}
             onClick={() =>
               dispatch(
                 showModal({
@@ -49,13 +47,9 @@ export default function AnswerCell({ row, value }) {
                 })
               )
             }
-          >
-            <Badge pill variant="light">
-              <FontAwesomeIcon icon={faEdit} />
-            </Badge>
-          </span>{" "}
-          <span
-            style={{ cursor: "pointer" }}
+          />{" "}
+          <ClickableIcon
+            icon={faTrashAlt}
             onClick={() =>
               dispatch(
                 showModal({
@@ -67,16 +61,12 @@ export default function AnswerCell({ row, value }) {
                 })
               )
             }
-          >
-            <Badge pill variant="light">
-              <FontAwesomeIcon icon={faTrashAlt} />
-            </Badge>
-          </span>
+          />
           <br />
         </React.Fragment>
       ))}
-      <span
-        style={{ cursor: "pointer" }}
+      <ClickableIcon
+        icon={faPlus}
         onClick={() =>
           dispatch(
             showModal({
@@ -88,11 +78,7 @@ export default function AnswerCell({ row, value }) {
             })
           )
         }
-      >
-        <Badge pill variant="light">
-          <FontAwesomeIcon icon={faPlus} />
-        </Badge>
-      </span>
+      />
     </>
   );
 }

--- a/hunts/src/ClickableIcon.js
+++ b/hunts/src/ClickableIcon.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+export default function ClickableIcon({ icon, onClick }) {
+  return (
+    <span
+      style={{ cursor: "pointer" }}
+      className="text-muted"
+      onClick={onClick}
+    >
+      <FontAwesomeIcon icon={icon} />
+    </span>
+  );
+}

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -1,10 +1,9 @@
 import React from "react";
 import Badge from "react-bootstrap/Badge";
-import Button from "react-bootstrap/Button";
 import { useSelector, useDispatch } from "react-redux";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEdit, faTrashAlt } from "@fortawesome/free-regular-svg-icons";
 import { showModal } from "./modalSlice";
+import ClickableIcon from "./ClickableIcon";
 
 export default function NameCell({ row, value }) {
   const { id: huntId } = useSelector((state) => state.hunt);
@@ -26,9 +25,13 @@ export default function NameCell({ row, value }) {
           <b>{value}</b>
         </span>
       )}{" "}
-      {row.values.is_meta ? <Badge variant="dark">META</Badge> : null}
-      <span
-        style={{ cursor: "pointer" }}
+      {row.values.is_meta ? (
+        <>
+          <Badge variant="dark">META</Badge>{" "}
+        </>
+      ) : null}
+      <ClickableIcon
+        icon={faEdit}
         onClick={() =>
           dispatch(
             showModal({
@@ -43,13 +46,9 @@ export default function NameCell({ row, value }) {
             })
           )
         }
-      >
-        <Badge pill variant="light">
-          <FontAwesomeIcon icon={faEdit} />
-        </Badge>
-      </span>{" "}
-      <span
-        style={{ cursor: "pointer" }}
+      />{" "}
+      <ClickableIcon
+        icon={faTrashAlt}
         onClick={() =>
           dispatch(
             showModal({
@@ -62,11 +61,7 @@ export default function NameCell({ row, value }) {
             })
           )
         }
-      >
-        <Badge pill variant="light">
-          <FontAwesomeIcon icon={faTrashAlt} />
-        </Badge>
-      </span>
+      />
     </>
   );
 }

--- a/hunts/src/TagCell.js
+++ b/hunts/src/TagCell.js
@@ -1,11 +1,10 @@
 import React from "react";
-import Badge from "react-bootstrap/Badge";
 import { useDispatch, useSelector } from "react-redux";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { showModal } from "./modalSlice";
 import { toggleFilterTag } from "./filterSlice";
 import TagPill from "./TagPill";
+import ClickableIcon from "./ClickableIcon";
 
 function TagCell({ row, value }) {
   const dispatch = useDispatch();
@@ -22,9 +21,9 @@ function TagCell({ row, value }) {
           key={name}
           onClick={() => dispatch(toggleFilterTag({ name, color, id }))}
         />
-      ))}
-      <span
-        style={{ cursor: "pointer" }}
+      ))}{" "}
+      <ClickableIcon
+        icon={faPlus}
         onClick={() =>
           dispatch(
             showModal({
@@ -36,11 +35,7 @@ function TagCell({ row, value }) {
             })
           )
         }
-      >
-        <Badge pill variant="light">
-          <FontAwesomeIcon icon={faPlus} />
-        </Badge>
-      </span>
+      />
     </>
   );
 }


### PR DESCRIPTION
The UI needs more work than this (especially the answer cell) but I think it's a step in the right direction. Looks a lot cleaner to me without twenty pills popping out the screen at once.

Before: 
![image](https://user-images.githubusercontent.com/3475509/148320373-bccfcd78-b0bf-4656-bba3-b09aae01d999.png)

After:
![image](https://user-images.githubusercontent.com/3475509/148320403-11f221b4-0b2a-4837-973d-7fcdfefc856c.png)
