### PR TITLE
load .env file in celery workers

### DIFF
--- a/cardboard/celery.py
+++ b/cardboard/celery.py
@@ -1,9 +1,15 @@
 import os
+import dotenv
 
 from celery import Celery
 
 # set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cardboard.settings")
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+dotenv_file = os.path.join(BASE_DIR, ".env")
+if os.path.isfile(dotenv_file):
+    dotenv.load_dotenv(dotenv_file)
 
 app = Celery("cardboard")
 


### PR DESCRIPTION
Pipenv would automatically load .env files, so it didn't matter if the celery workers didn't. Celery stopped working in local development after switching to poetry, which ignores .env files. It didn't break prod, since the environment variables are set in the Heroku apps instead of through .envs.