### PR TITLE
Change puzzle/sheet/chat links to a softer color

### DIFF
--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -64,7 +64,7 @@ const TABLE_COLUMNS = [
     Header: "Puzzle",
     accessor: "url",
     Cell: ({ row, value }) => (
-      <a href={value} target="_blank">
+      <a href={value} target="_blank" className="text-info">
         Puzzle
       </a>
     ),
@@ -74,7 +74,11 @@ const TABLE_COLUMNS = [
     accessor: "has_sheet",
     Cell: ({ row, value }) =>
       value ? (
-        <a href={`${SHEET_REDIRECT_BASE}/${row.original.id}`} target="_blank">
+        <a
+          href={`${SHEET_REDIRECT_BASE}/${row.original.id}`}
+          target="_blank"
+          className="text-info"
+        >
           Sheet
         </a>
       ) : null,
@@ -85,7 +89,11 @@ const TABLE_COLUMNS = [
     Cell: ({ row, value }) =>
       row.original.chat_room ? (
         <>
-          <a href={row.original.chat_room.text_channel_url} target="_blank">
+          <a
+            href={row.original.chat_room.text_channel_url}
+            target="_blank"
+            className="text-info"
+          >
             Channel
           </a>
         </>


### PR DESCRIPTION
Trying to stick with Bootstrap colors for now. I think this makes them less prominent/so they don't compete for attention with the big answer/solve buttons. Still underlines & changes color on hover so it still looks like a link. 

Old: ![image](https://user-images.githubusercontent.com/3475509/148348151-76d24c31-c107-4324-ae95-f978bd66c7ae.png)

This version (.text-info): 
![image](https://user-images.githubusercontent.com/3475509/148348227-966d36c7-aff6-4e91-8f4f-08b424720506.png)

Alternate (text-secondary):
![image](https://user-images.githubusercontent.com/3475509/148348384-faaa4343-0173-46f8-b2ad-ac9541cb6ad0.png)

Alternate (text-dark); I don't like this one since it doesn't look like a link: 
![image](https://user-images.githubusercontent.com/3475509/148348591-1f5489a9-931a-4d0d-a9d5-8bf7282f1713.png)
