### PR TITLE
clean up channels 30 minutes after puzzle solve

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -124,7 +124,7 @@ class AnswerViewSet(viewsets.ModelViewSet):
                     transaction.on_commit(
                         lambda: chat.tasks.handle_puzzle_unsolved.delay(puzzle.id)
                     )
-                else:
+                elif settings.CHAT_DEFAULT_SERVICE:
                     transaction.on_commit(
                         lambda: chat.tasks.create_chat_for_puzzle.delay(puzzle.id)
                     )

--- a/api/views.py
+++ b/api/views.py
@@ -125,6 +125,7 @@ class AnswerViewSet(viewsets.ModelViewSet):
                         lambda: chat.tasks.handle_puzzle_unsolved.delay(puzzle.id)
                     )
                 elif settings.CHAT_DEFAULT_SERVICE:
+                    # recreate chat if they had already been cleaned up from being marked as SOLVED
                     transaction.on_commit(
                         lambda: chat.tasks.create_chat_for_puzzle.delay(puzzle.id)
                     )

--- a/chat/service.py
+++ b/chat/service.py
@@ -28,6 +28,9 @@ class ChatService:
     def create_text_channel(self, name):
         raise NotImplementedError
 
+    def get_text_channel_participants(self, channel_id):
+        raise NotImplementedError
+
     def delete_text_channel(self, channel_id):
         raise NotImplementedError
 

--- a/discord_lib/discord_chat_service.py
+++ b/discord_lib/discord_chat_service.py
@@ -49,6 +49,11 @@ class DiscordChatService(ChatService):
         )
         return channel.id
 
+    def get_text_channel_participants(self, channel_id):
+        messages = self._client.channels_messages_list(channel_id)
+        usernames = [m.author.username for m in messages if not m.author.bot]
+        return list(set(usernames))
+
     def delete_text_channel(self, channel_id):
         self.delete_channel(channel_id)
 


### PR DESCRIPTION
Delete voice channels and text channels that contain no non-bot messages 30 minutes after a puzzle is marked as SOLVED.

For puzzles with multiple answers, the cleanup is avoided by marking the puzzle as SOLVING after putting in the first answer.