### PR TITLE
Table column width fixes

### DIFF
--- a/hunts/src/LinkCell.js
+++ b/hunts/src/LinkCell.js
@@ -73,13 +73,18 @@ export const LinkCell = ({ row }) => {
   const discordLink = createDiscordLink(puzzle, chatVersion);
 
   return (
-    <>
+    <div
+      style={{
+        width: "110px",
+      }}
+    >
       <IconLink
         icon={faPuzzlePiece}
         url={puzzleLink}
         size="lg"
         style={{
           margin: "0 5px",
+          display: "inline-block",
         }}
       ></IconLink>
 
@@ -89,6 +94,7 @@ export const LinkCell = ({ row }) => {
           style={{
             margin: "0 5px",
             fill: "currentColor",
+            display: "inline-block",
           }}
         >
           <SheetsSvg />
@@ -101,11 +107,12 @@ export const LinkCell = ({ row }) => {
           style={{
             margin: "0 5px",
             fill: "currentColor",
+            display: "inline-block",
           }}
         >
           <DiscordSvg />
         </SvgLink>
       ) : null}
-    </>
+    </div>
   );
 };

--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -23,22 +23,26 @@ const TABLE_COLUMNS = [
     Header: "Name",
     accessor: "name",
     Cell: NameCell,
+    className: "col-5",
   },
   {
     Header: "Answer",
     accessor: (row) => row.guesses.map(({ text }) => text).join(" "),
     Cell: AnswerCell,
     id: "answer",
+    className: "col-2",
   },
   {
     Header: "Status",
     accessor: "status",
     Cell: StatusCell,
     filter: "solvedFilter",
+    className: "col-1",
   },
   {
     Header: "Links",
     Cell: LinkCell,
+    className: "col-1",
   },
   {
     Header: "Tags/Metas",
@@ -46,6 +50,7 @@ const TABLE_COLUMNS = [
     accessor: (row) => row.tags.map(({ name }) => name).join(" "),
     Cell: TagCell,
     filter: "tagsFilter",
+    className: "col-3",
   },
   {
     accessor: "is_meta",
@@ -167,7 +172,9 @@ export const PuzzleTable = React.memo(({ data, filterSolved, filterTags }) => {
           <tr>
             {allColumns.map((column) =>
               column.isVisible ? (
-                <th {...column.getHeaderProps()}>{column.render("Header")}</th>
+                <th {...column.getHeaderProps()} className={column.className}>
+                  {column.render("Header")}
+                </th>
               ) : null
             )}
           </tr>


### PR DESCRIPTION
* Force the links to always appear on one line (previously they break onto two or three lines as the screen shrinks)
* Set some basic proportions for the columns widths (tested using last year's hunts and a new hunt)

Last year's MH on my full width laptop screen: 
![image](https://user-images.githubusercontent.com/3475509/148874591-acde31ae-9957-4a24-8b13-3a58e9d4719d.png)

Empty hunt on full width laptop screen:
![image](https://user-images.githubusercontent.com/3475509/148874765-9c2f3d70-8d51-40fd-a1c7-6a9c2ed131d3.png)

As the screen width goes down this matters less and less because the table layout is constrained by wide elements (long answers/tags/words)
