### PR TITLE
Don't redirect to most recent hunt if it's not active

### DIFF
--- a/hunts/views.py
+++ b/hunts/views.py
@@ -104,7 +104,7 @@ class LastAccessedHuntRedirectView(LoginRequiredMixin, RedirectView):
 
     def get_redirect_url(self, *args, **kwargs):
         hunt = self.request.user.last_accessed_hunt
-        if not hunt:
+        if not hunt or not hunt.active:
             return reverse("hunts:index")
         kwargs["hunt_slug"] = hunt.slug
         return super().get_redirect_url(*args, **kwargs)


### PR DESCRIPTION
Otherwise everyone from last year will get sent to the 2021 hunt page after logging in. This way they get sent to the index page.