### PR TITLE
Use the Drive folder ID for storing puzzle files instead of the same directory as the template

### DIFF
--- a/google_api_lib/tests.py
+++ b/google_api_lib/tests.py
@@ -20,6 +20,10 @@ def mock_add_puzzle_link_to_sheet(puzzle_url, sheet_url):
     return
 
 
+def mock_move_drive_file(file_id, destination_folder_id):
+    return
+
+
 class TestGoogleSheets(TestCase):
     def setUp(self):
         self.client.login(username="test", password="testingpwd")
@@ -39,6 +43,7 @@ class TestGoogleSheets(TestCase):
         "google_api_lib.tasks.transfer_ownership.delay",
         mock_transfer_ownership,
     )
+    @patch("google_api_lib.tasks.move_drive_file.delay", mock_move_drive_file)
     @patch(
         "google_api_lib.tasks.add_puzzle_link_to_sheet", mock_add_puzzle_link_to_sheet
     )

--- a/hunts/models.py
+++ b/hunts/models.py
@@ -152,8 +152,8 @@ class HuntSettings(models.Model):
 
     # The id of your Google Drive folder
     # This should be part of the URL (https://drive.google.com/drive/folders/<folder_id>)
-    # TODO(#514): use this as the destination for puzzle sheets, instead of defaulting to the
-    # directory of the template file
+    # This folder is used for login permissions and for puzzle storage.
+    # This is where puzzle files will be kept, so it should not be modified by humans
     google_drive_folder_id = models.CharField(max_length=128, blank=True)
 
     # The id of your Google Sheets template file


### PR DESCRIPTION
Fixes #541

This lets us keep the template in a different location from the puzzle files, which is useful
if we're potentially going to make a bunch of copies of the template in advance and need to
distinguish those from puzzle sheets.