### PR TITLE
Fix the backsolved tag/sheet renaming interaction

### DIFF
--- a/puzzles/models.py
+++ b/puzzles/models.py
@@ -196,7 +196,10 @@ class Puzzle(models.Model):
         return field_url_map
 
     def is_backsolved(self):
-        return self.tags.filter(name=Puzzle.BACKSOLVED_TAG, hunt=self.hunt).exists()
+        return (
+            self.is_solved()
+            and self.tags.filter(name=Puzzle.BACKSOLVED_TAG, hunt=self.hunt).exists()
+        )
 
     @staticmethod
     def maybe_truncate_name(name):

--- a/puzzles/tests.py
+++ b/puzzles/tests.py
@@ -199,5 +199,5 @@ class TestPuzzle(APITestCase):
             f"/api/v1/puzzles/{feeder.pk}/tags",
             {"name": Puzzle.BACKSOLVED_TAG.lower(), "color": "primary"},
         )
-        # Not backsolved as it hasn't been solved yet
+        # Now it should be backsolved again
         self.assertTrue(feeder.is_backsolved())


### PR DESCRIPTION
I broke this when I changed the casing of the default tags. Making this case-insensitive.