### PR TITLE
Add separate review app add-on plans

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,5 +10,10 @@
         {
             "url": "heroku/python"
         }
-    ]
+    ],
+    "environments": {
+        "review": {
+            "addons": ["heroku-postgresql:hobby-dev", "heroku-redis:hobby-dev"]
+        }
+    }
 }


### PR DESCRIPTION
I think (?)

Before they were pointing at our prod database (yikes) which caused problems with migrations. This should give them their own config vars.