### PR TITLE
fix backfill migrations

### DIFF
--- a/hunts/migrations/0008_huntsettings_backfill.py
+++ b/hunts/migrations/0008_huntsettings_backfill.py
@@ -4,6 +4,13 @@ from django.template.defaultfilters import slugify
 from django.conf import settings
 
 
+def get_setting(settings, var):
+    if hasattr(settings, var):
+        return getattr(settings, var) or ""
+    else:
+        return ""
+
+
 def add_settings(apps, schema_editor):
     Hunt = apps.get_model("hunts", "Hunt")
     HuntSettings = apps.get_model("hunts", "HuntSettings")
@@ -11,18 +18,25 @@ def add_settings(apps, schema_editor):
         if not hasattr(hunt, "settings"):
             hunt_settings = HuntSettings(
                 hunt=hunt,
-                google_drive_folder_id=settings.GOOGLE_DRIVE_HUNT_FOLDER_ID or "",
-                google_sheets_template_file_id=settings.GOOGLE_SHEETS_TEMPLATE_FILE_ID
-                or "",
-                google_drive_human_url=settings.GOOGLE_HUMAN_DRIVE_HUNT_FOLDER_URL
-                or "",
-                discord_guild_id=settings.DISCORD_GUILD_ID or "",
-                discord_puzzle_announcements_channel_id=settings.DISCORD_PUZZLE_ANNOUNCEMENTS_CHANNEL
-                or "",
-                discord_text_category=settings.DISCORD_TEXT_CATEGORY or "",
-                discord_voice_category=settings.DISCORD_VOICE_CATEGORY or "",
-                discord_archive_category=settings.DISCORD_ARCHIVE_CATEGORY or "",
-                discord_devs_role=settings.DISCORD_DEVS_ROLE or "",
+                google_drive_folder_id=get_setting(
+                    settings, "GOOGLE_DRIVE_HUNT_FOLDER_ID"
+                ),
+                google_sheets_template_file_id=get_setting(
+                    settings, "GOOGLE_SHEETS_TEMPLATE_FILE_ID"
+                ),
+                google_drive_human_url=get_setting(
+                    settings, "GOOGLE_HUMAN_DRIVE_HUNT_FOLDER_URL"
+                ),
+                discord_guild_id=get_setting(settings, "DISCORD_GUILD_ID"),
+                discord_puzzle_announcements_channel_id=get_setting(
+                    settings, "DISCORD_PUZZLE_ANNOUNCEMENTS_CHANNEL"
+                ),
+                discord_text_category=get_setting(settings, "DISCORD_TEXT_CATEGORY"),
+                discord_voice_category=get_setting(settings, "DISCORD_VOICE_CATEGORY"),
+                discord_archive_category=get_setting(
+                    settings, "DISCORD_ARCHIVE_CATEGORY"
+                ),
+                discord_devs_role=get_setting(settings, "DISCORD_DEVS_ROLE"),
             )
             hunt_settings.save()
 


### PR DESCRIPTION
#573 broke this migration since it removed DISCORD_GUILD_ID from settings.

We can wait until after the hunt to merge this in.