### PR TITLE
Change celery concurrency to max 2 processes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 release: python manage.py migrate --noinput
 web: gunicorn cardboard.wsgi --log-file -
-worker: celery -A cardboard worker -l INFO --without-heartbeat --without-gossip --without-mingle
+worker: celery -A cardboard worker -l INFO --without-heartbeat --without-gossip --without-mingle --concurrency 2
 bot: python manage.py rundiscordbot


### PR DESCRIPTION
It defaults to one per core, but our dyno has 8 cores and 8 processes use too much memory