### PR TITLE
add puzzle links to sheet at creation

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -332,7 +332,7 @@ class SheetTests(CardboardTestCase, TransactionTestCase):
         google_api_lib.tests.mock_transfer_ownership,
     )
     @patch(
-        "google_api_lib.tasks.add_puzzle_link_to_sheet",
+        "google_api_lib.tasks.add_puzzle_link_to_sheet.delay",
         google_api_lib.tests.mock_add_puzzle_link_to_sheet,
     )
     def test_sheets_title_editing(self, rename_sheet):
@@ -390,7 +390,7 @@ class SheetTests(CardboardTestCase, TransactionTestCase):
         google_api_lib.tests.mock_transfer_ownership,
     )
     @patch(
-        "google_api_lib.tasks.add_puzzle_link_to_sheet",
+        "google_api_lib.tasks.add_puzzle_link_to_sheet.delay",
         google_api_lib.tests.mock_add_puzzle_link_to_sheet,
     )
     def test_sheets_title_editing_case_insensitive(self, rename_sheet):

--- a/google_api_lib/tasks.py
+++ b/google_api_lib/tasks.py
@@ -119,6 +119,7 @@ def create_google_sheets(self, puzzle_id) -> None:
                 rename_sheet.delay(sheet_url, puzzle.name)
 
             transfer_ownership.delay(new_file, template_file_id)
+            add_puzzle_link_to_sheet.delay(puzzle.url, sheet_url)
 
             if destination_folder_id:
                 move_drive_file.delay(


### PR DESCRIPTION
Fixes #590 

For some reason, `add_puzzle_link_to_sheet` was not called during puzzle creation, and only being called when puzzle's URL changed.