### PR TITLE
Keep collapsed puzzles in local storage

### DIFF
--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -17,7 +17,7 @@ const useToggleRowExpandedProps = (row) => {
   return {
     ...originalProps,
     onClick: (e) => {
-      dispatch(toggleCollapsed({ rowId: row.id }));
+      dispatch(toggleCollapsed({ rowId: row.id, huntId: CURRENT_HUNT_ID }));
       return originalProps.onClick(e);
     },
   };

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -25,12 +25,12 @@ const useToggleRowExpandedProps = (row) => {
 
 export default function NameCell({ row, value }) {
   const { id: huntId } = useSelector((state) => state.hunt);
-  const props = useToggleRowExpandedProps(row);
+  const toggleRowExpandedProps = useToggleRowExpandedProps(row);
   const dispatch = useDispatch();
   return (
     <>
       {row.canExpand ? (
-        <span {...props}>
+        <span {...toggleRowExpandedProps}>
           {row.isExpanded ? "▼" : "▶"} <b>{value}</b>
         </span>
       ) : (

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -4,20 +4,33 @@ import { useSelector, useDispatch } from "react-redux";
 import { faEdit, faTrashAlt } from "@fortawesome/free-regular-svg-icons";
 import { showModal } from "./modalSlice";
 import ClickableIcon from "./ClickableIcon";
+import { toggleCollapsed } from "./collapsedPuzzlesSlice";
+
+const useToggleRowExpandedProps = (row) => {
+  const dispatch = useDispatch();
+  const originalProps = row.getToggleRowExpandedProps({
+    style: {
+      paddingLeft: `${row.depth * 2}rem`,
+    },
+  });
+
+  return {
+    ...originalProps,
+    onClick: (e) => {
+      dispatch(toggleCollapsed({ rowId: row.id }));
+      return originalProps.onClick(e);
+    },
+  };
+};
 
 export default function NameCell({ row, value }) {
   const { id: huntId } = useSelector((state) => state.hunt);
+  const props = useToggleRowExpandedProps(row);
   const dispatch = useDispatch();
   return (
     <>
       {row.canExpand ? (
-        <span
-          {...row.getToggleRowExpandedProps({
-            style: {
-              paddingLeft: `${row.depth * 2}rem`,
-            },
-          })}
-        >
+        <span {...props}>
           {row.isExpanded ? "▼" : "▶"} <b>{value}</b>
         </span>
       ) : (

--- a/hunts/src/collapsedPuzzlesSlice.js
+++ b/hunts/src/collapsedPuzzlesSlice.js
@@ -6,11 +6,22 @@ export const collapsedPuzzlesSlice = createSlice({
   initialState: {},
   reducers: {
     toggleCollapsed: (state, action) => {
-      state[`${action.payload.rowId}`] = !state[`${action.payload.rowId}`];
+      if (!state.hasOwnProperty(action.payload.huntId)) {
+        state[action.payload.huntId] = {};
+      }
+      const currentHunt = state[action.payload.huntId];
+      currentHunt[`${action.payload.rowId}`] = !currentHunt[
+        `${action.payload.rowId}`
+      ];
     },
   },
 });
 
 export const { toggleCollapsed } = collapsedPuzzlesSlice.actions;
 export default collapsedPuzzlesSlice.reducer;
-export const getCollapsedPuzzles = (state) => state.collapsedPuzzles;
+export const getCollapsedPuzzles = (huntId) => (state) => {
+  if (!state.collapsedPuzzles.hasOwnProperty(huntId)) {
+    return {};
+  }
+  return state.collapsedPuzzles[huntId];
+};

--- a/hunts/src/collapsedPuzzlesSlice.js
+++ b/hunts/src/collapsedPuzzlesSlice.js
@@ -10,9 +10,7 @@ export const collapsedPuzzlesSlice = createSlice({
         state[action.payload.huntId] = {};
       }
       const currentHunt = state[action.payload.huntId];
-      currentHunt[`${action.payload.rowId}`] = !currentHunt[
-        `${action.payload.rowId}`
-      ];
+      currentHunt[action.payload.rowId] = !currentHunt[action.payload.rowId];
     },
   },
 });

--- a/hunts/src/collapsedPuzzlesSlice.js
+++ b/hunts/src/collapsedPuzzlesSlice.js
@@ -1,0 +1,16 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+// This slice is primarily used to sync changes to local storage.
+export const collapsedPuzzlesSlice = createSlice({
+  name: "collapsedPuzzles",
+  initialState: {},
+  reducers: {
+    toggleCollapsed: (state, action) => {
+      state[`${action.payload.rowId}`] = !state[`${action.payload.rowId}`];
+    },
+  },
+});
+
+export const { toggleCollapsed } = collapsedPuzzlesSlice.actions;
+export default collapsedPuzzlesSlice.reducer;
+export const getCollapsedPuzzles = (state) => state.collapsedPuzzles;

--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -19,6 +19,7 @@ import CreationCell from "./CreationCell";
 import TagCell from "./TagCell";
 import { LinkCell } from "./LinkCell";
 import { getCollapsedPuzzles } from "./collapsedPuzzlesSlice";
+import { selectHuntId } from "./huntSlice";
 
 const TABLE_COLUMNS = [
   {
@@ -135,7 +136,7 @@ export const PuzzleTable = React.memo(({ data, filterSolved, filterTags }) => {
     }
   }, []);
 
-  const collapsedPuzzles = useSelector(getCollapsedPuzzles);
+  const collapsedPuzzles = useSelector(getCollapsedPuzzles(CURRENT_HUNT_ID));
 
   const {
     getTableProps,

--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -18,6 +18,7 @@ import StatusCell from "./StatusCell";
 import CreationCell from "./CreationCell";
 import TagCell from "./TagCell";
 import { LinkCell } from "./LinkCell";
+import { getCollapsedPuzzles } from "./collapsedPuzzlesSlice";
 
 const TABLE_COLUMNS = [
   {
@@ -133,6 +134,9 @@ export const PuzzleTable = React.memo(({ data, filterSolved, filterTags }) => {
       return row.id.toString();
     }
   }, []);
+
+  const collapsedPuzzles = useSelector(getCollapsedPuzzles);
+
   const {
     getTableProps,
     getTableBodyProps,
@@ -158,6 +162,9 @@ export const PuzzleTable = React.memo(({ data, filterSolved, filterTags }) => {
       initialState: {
         hiddenColumns: ["is_meta", "id", "url"],
         filters: [],
+        // Apparently our patch of react-table introduces the 'collapsed'
+        // object that has the opposite semantics of the 'expanded' API.
+        collapsed: collapsedPuzzles,
       },
     },
     useGlobalFilter,

--- a/hunts/src/store.js
+++ b/hunts/src/store.js
@@ -5,16 +5,23 @@ import modalReducer from "./modalSlice";
 import alertReducer from "./alertSlice";
 import filterReducer from "./filterSlice";
 import chatReducer from "./chatSlice";
+import collapsedPuzzleReducer from "./collapsedPuzzlesSlice";
 import { save, load } from "redux-localstorage-simple";
 
 const preloadedState = load({
-  states: ["filter.solveStateFilter", "filter.tags", "chat.version"],
+  states: [
+    "filter.solveStateFilter",
+    "filter.tags",
+    "chat.version",
+    "collapsedPuzzles",
+  ],
 });
 
 export default configureStore({
   reducer: {
     modal: modalReducer,
     alert: alertReducer,
+    collapsedPuzzles: collapsedPuzzleReducer,
     puzzles: puzzlesReducer,
     hunt: huntReducer,
     filter: filterReducer,
@@ -23,7 +30,12 @@ export default configureStore({
   middleware: (getDefaultMiddlewares) => [
     ...getDefaultMiddlewares(),
     save({
-      states: ["filter.solveStateFilter", "filter.tags", "chat.version"],
+      states: [
+        "filter.solveStateFilter",
+        "filter.tags",
+        "chat.version",
+        "collapsedPuzzles",
+      ],
     }),
   ],
   preloadedState,


### PR DESCRIPTION
We have a utility reflecting sections of our redux state into local storage. This PR adds a slice that tracks which puzzles are collapsed and preloads react-table with that information.

https://github.com/cardinalitypuzzles/cardboard/issues/607