### PR TITLE
Adds settings variables to control app branding.

### DIFF
--- a/cardboard/context_processors.py
+++ b/cardboard/context_processors.py
@@ -9,5 +9,10 @@ def google_auth(request):
     }
 
 
-def contact_email(request):
-    return {"CONTACT_EMAIL": settings.CONTACT_EMAIL}
+def app_info(request):
+    return {
+        "APP_SHORT_TITLE": settings.APP_SHORT_TITLE,
+        "APP_TITLE": settings.APP_TITLE,
+        "CONTACT_AUTHOR_NAME": settings.CONTACT_AUTHOR_NAME,
+        "CONTACT_EMAIL": settings.CONTACT_EMAIL,
+    }

--- a/cardboard/settings.py
+++ b/cardboard/settings.py
@@ -104,7 +104,7 @@ TEMPLATES = [
                 "social_django.context_processors.backends",
                 "social_django.context_processors.login_redirect",
                 "cardboard.context_processors.google_auth",
-                "cardboard.context_processors.contact_email",
+                "cardboard.context_processors.app_info",
             ],
         },
     },
@@ -180,7 +180,12 @@ DATABASES = {}
 DATABASES["default"] = dj_database_url.config(conn_max_age=600, ssl_require=False)
 DATABASES["default"]["TEST"] = {"NAME": "test_cardboard"}
 
-# Contact email
+# App title
+APP_TITLE = os.environ.get("APP_TITLE", "Cardinality Cardboard")
+APP_SHORT_TITLE = os.environ.get("APP_SHORT_TITLE", "Cardboard")
+
+# Contact info
+CONTACT_AUTHOR_NAME = os.environ.get("CONTACT_AUTHOR_NAME", "Cardinality")
 CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL", "FIXME@FIXME.COM")
 
 # Discord API. See

--- a/cardboard/templates/base.html
+++ b/cardboard/templates/base.html
@@ -1,7 +1,7 @@
 {% load static %}
 <html lang="en">
     <head>
-        <title>Cardinality Cardboard</title>
+        <title>{{ APP_TITLE }}</title>
         <link rel="shortcut icon" type="image/png" href="{% static 'favicon.ico' %}"/>
 
         <!-- https://github.com/ForEvolve/bootstrap-dark -->
@@ -57,7 +57,7 @@
         <nav class="navbar navbar-expand-lg navbar-themed">
             <a class="navbar-brand" href="/">
                 <img height="40" src="{% static 'favicon.ico' %}" alt="">
-                Cardboard
+                {{ APP_SHORT_TITLE }}
             </a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>

--- a/cardboard/templates/home.html
+++ b/cardboard/templates/home.html
@@ -8,7 +8,7 @@
     <div class="row">
         <div class="col-sm">
 
-            <h1>Cardinality Cardboard</h1>
+            <h1>{{ APP_TITLE }}</h1>
 
 
             <ul>

--- a/cardboard/templates/privacy.html
+++ b/cardboard/templates/privacy.html
@@ -5,7 +5,7 @@
     <h1>Privacy Policy</h1>
     <p>Last updated: December 19, 2020</p>
 
-    <p>Cardinality ("us", "we", or "our") operates <a href="{{ request.scheme }}://{{ request.get_host }}">{{ request.get_host }}</a> (the "site"). This page informs you of our policies regarding the collection, use, and disclosure of personal information we receive from users of the site.</p>
+    <p>{{ CONTACT_AUTHOR_NAME }} ("us", "we", or "our") operates <a href="{{ request.scheme }}://{{ request.get_host }}">{{ request.get_host }}</a> (the "site"). This page informs you of our policies regarding the collection, use, and disclosure of personal information we receive from users of the site.</p>
 
     <p>We use your personal information only for providing and improving the site. By using the site, you agree to the collection and use of information in accordance with this policy.</p>
 

--- a/cardboard/templates/reactbase.html
+++ b/cardboard/templates/reactbase.html
@@ -1,7 +1,7 @@
 {% load static %}
 <html lang="en">
     <head>
-        <title>Cardinality Cardboard</title>
+        <title>{{ APP_TITLE }}</title>
         <link rel="shortcut icon" type="image/png" href="{% static 'favicon.ico' %}"/>
 
         <!-- https://github.com/ForEvolve/bootstrap-dark -->
@@ -53,6 +53,7 @@
         </div>
         <script>
            LOGGED_IN_USER = `{% if user.first_name %}{{user.first_name}} {{user.last_name}}{% else %}{{ user.username }}{% endif %}{% if user.email %} ({{user.email}}){% endif %}`
+           APP_SHORT_TITLE = `{{ APP_SHORT_TITLE }}`
         </script>
     </body>
 

--- a/hunts/src/SiteHeader.js
+++ b/hunts/src/SiteHeader.js
@@ -19,7 +19,7 @@ export const SiteHeader = () => {
         style={{ marginBottom: "5px" }}
       >
         <a className="navbar-brand" href="/">
-          <img height="40" src="/static/favicon.ico" alt="" /> Cardboard
+          <img height="40" src="/static/favicon.ico" alt="" /> {window.APP_SHORT_TITLE}
         </a>
         {hunt.name}
         <button type="button" className="btn ml-auto" onClick={toggleDrawer}>

--- a/new-hunt-setup.md
+++ b/new-hunt-setup.md
@@ -143,6 +143,9 @@ Miscellaneous configs:
 
 * `DJANGO_SECRET_KEY` - used by Django to generate secrets, such as for user sessions. It's best to set this so that user sessions will not expire after each restart. You can generate a key using `python -c "import secrets; print(secrets.token_urlsafe())"`.
 * `DEBUG` - you probably want to set this to `False` in production so users don't get gory error pages and so profiling is disabled.
+* `APP_TITLE` - app title for page titles and headers
+* `APP_SHORT_TITLE` - short version of the app title for the nav bar
+* `CONTACT_AUTHOR_NAME` - contact name for privacy statement
 * `CONTACT_EMAIL` - contact email for login help and privacy statement
 
 #### Discord role pings


### PR DESCRIPTION
(Continuing to upstream my local diffs.)

When I set up a site for my team, it felt wrong to keep the "Cardinality" branding. If you agree, here's an attempt to make the branding configurable. I've kept the defaults unchanged, so there should be no visible changes unless you set the appropriate env variables.