### PR TITLE
fix discord channel cleanup

### DIFF
--- a/chat/models.py
+++ b/chat/models.py
@@ -171,14 +171,12 @@ class ChatRoom(models.Model):
             self.audio_channel_url = ""
             update_fields.extend(["audio_channel_id", "audio_channel_url"])
 
-        if self.text_channel_id is not None:
+        if self.text_channel_id:
             if check_if_used:
                 participants = service.get_text_channel_participants(
                     self.text_channel_id
                 )
-                should_delete_text_channel = (
-                    participants is not None and len(participants) == 0
-                )
+                should_delete_text_channel = participants and len(participants) == 0
             else:
                 should_delete_text_channel = True
 

--- a/chat/models.py
+++ b/chat/models.py
@@ -165,6 +165,12 @@ class ChatRoom(models.Model):
         service = self.get_service()
         update_fields = []
 
+        if self.audio_channel_id:
+            service.delete_audio_channel(self.audio_channel_id)
+            self.audio_channel_id = None
+            self.audio_channel_url = ""
+            update_fields.extend(["audio_channel_id", "audio_channel_url"])
+
         if self.text_channel_id is not None:
             if check_if_used:
                 participants = service.get_text_channel_participants(
@@ -184,11 +190,7 @@ class ChatRoom(models.Model):
             self.text_channel_id = None
             self.text_channel_url = ""
             update_fields.extend(["text_channel_id", "text_channel_url"])
-        if self.audio_channel_id:
-            service.delete_audio_channel(self.audio_channel_id)
-            self.audio_channel_id = None
-            self.audio_channel_url = ""
-            update_fields.extend(["audio_channel_id", "audio_channel_url"])
+
         if update_fields:
             self.save(update_fields=update_fields)
 

--- a/chat/models.py
+++ b/chat/models.py
@@ -165,10 +165,19 @@ class ChatRoom(models.Model):
         service = self.get_service()
         update_fields = []
 
-        should_delete_text_channel = (self.text_channel_id is not None) and (
-            not check_if_used
-            or (len(service.get_text_channel_participants(self.text_channel_id)) == 0)
-        )
+        if self.text_channel_id is not None:
+            if check_if_used:
+                participants = service.get_text_channel_participants(
+                    self.text_channel_id
+                )
+                should_delete_text_channel = (
+                    participants is not None and len(participants) == 0
+                )
+            else:
+                should_delete_text_channel = True
+
+        else:
+            should_delete_text_channel = False
 
         if should_delete_text_channel:
             service.delete_text_channel(self.text_channel_id)

--- a/chat/tasks.py
+++ b/chat/tasks.py
@@ -59,12 +59,7 @@ def cleanup_puzzle_channels(puzzle_id):
         if solved_time is None:
             return
 
-        now = datetime.now(tz=solved_time.tzinfo)
-        if now - solved_time > timedelta(minutes=30):
-            try:
-                puzzle.chat_room.delete_channels(check_if_used=True)
-            except Exception as e:
-                logger.warn(f"cleanup_puzzle_channels failed with error: {e}")
+        puzzle.chat_room.delete_channels(check_if_used=True)
 
 
 # Disco-py actually kills the process when it is rate limited instead of throwing an exception

--- a/discord_lib/discord_chat_service.py
+++ b/discord_lib/discord_chat_service.py
@@ -1,5 +1,6 @@
 import json
 from collections import defaultdict
+from typing import List, Optional
 
 import requests
 
@@ -76,11 +77,21 @@ class DiscordChatService(ChatService):
             parent_name=text_category_name,
         )
 
-    def get_text_channel_participants(self, channel_id):
-        # messages = self._client.channels_messages_list(channel_id)
-        # usernames = [m.author.username for m in messages if not m.author.bot]
-        # return list(set(usernames))
-        return
+    def get_text_channel_participants(self, channel_id) -> Optional[List[str]]:
+        try:
+            response = requests.get(
+                f"{DISCORD_BASE_API_URL}/channels/{channel_id}/messages",
+                headers=self._headers,
+                timeout=5,
+            )
+            messages = json.loads(response.content.decode("utf-8"))
+            usernames = [
+                m["author"]["username"] for m in messages if not m["author"]["bot"]
+            ]
+            return list(set(usernames))
+        except Exception as e:
+            print(f"Error getting channel messages: {e}")
+            return None
 
     def delete_text_channel(self, channel_id):
         self.delete_channel(channel_id)

--- a/discord_lib/discord_chat_service.py
+++ b/discord_lib/discord_chat_service.py
@@ -91,7 +91,6 @@ class DiscordChatService(ChatService):
             return list(set(usernames))
         except Exception as e:
             print(f"Error getting channel messages: {e}")
-            return None
 
     def delete_text_channel(self, channel_id):
         self.delete_channel(channel_id)


### PR DESCRIPTION
Celery job to clean up solved puzzle's channels was broken because `get_text_channel_participants` had not been re-implemented