### PR TITLE
Display puzzle name and answer editing buttons on hover.

### DIFF
--- a/hunts/src/AnswerCell.js
+++ b/hunts/src/AnswerCell.js
@@ -32,14 +32,22 @@ export default function AnswerCell({ row }) {
   return (
     <>
       {row.original.guesses.map(({ id, text }) => (
-        <div key={text} onMouseOver={() => {
-          setUiHovered(uiHovered.concat(id));
-        }}
+        <div
+          key={text}
+          onMouseOver={() => {
+            setUiHovered(uiHovered.concat(id));
+          }}
           onMouseLeave={() => {
-            setUiHovered(uiHovered.filter(x => x != id));
-          }}>
+            setUiHovered(uiHovered.filter((x) => x != id));
+          }}
+        >
           <span className="text-monospace">{text}</span>{" "}
-          <div style={{ display: "inline-block", visibility: uiHovered.includes(id) ? "visible" : "hidden" }}>
+          <div
+            style={{
+              display: "inline-block",
+              visibility: uiHovered.includes(id) ? "visible" : "hidden",
+            }}
+          >
             <ClickableIcon
               icon={faEdit}
               onClick={() =>
@@ -68,8 +76,7 @@ export default function AnswerCell({ row }) {
                   })
                 )
               }
-            />
-            {" "}
+            />{" "}
             <ClickableIcon
               icon={faPlus}
               onClick={() =>

--- a/hunts/src/AnswerCell.js
+++ b/hunts/src/AnswerCell.js
@@ -8,6 +8,7 @@ import ClickableIcon from "./ClickableIcon";
 
 export default function AnswerCell({ row }) {
   const dispatch = useDispatch();
+  const [uiHovered, setUiHovered] = React.useState([]);
   if (row.original.guesses === undefined || row.original.guesses.length == 0) {
     return (
       <Button
@@ -31,54 +32,62 @@ export default function AnswerCell({ row }) {
   return (
     <>
       {row.original.guesses.map(({ id, text }) => (
-        <React.Fragment key={text}>
+        <div key={text} onMouseOver={() => {
+          setUiHovered(uiHovered.concat(id));
+        }}
+          onMouseLeave={() => {
+            setUiHovered(uiHovered.filter(x => x != id));
+          }}>
           <span className="text-monospace">{text}</span>{" "}
-          <ClickableIcon
-            icon={faEdit}
-            onClick={() =>
-              dispatch(
-                showModal({
-                  type: "EDIT_ANSWER",
-                  props: {
-                    puzzleId: row.values.id,
-                    answerId: id,
-                    text,
-                  },
-                })
-              )
-            }
-          />{" "}
-          <ClickableIcon
-            icon={faTrashAlt}
-            onClick={() =>
-              dispatch(
-                showModal({
-                  type: "DELETE_ANSWER",
-                  props: {
-                    puzzleId: row.values.id,
-                    answerId: id,
-                  },
-                })
-              )
-            }
-          />
+          <div style={{ display: "inline-block", visibility: uiHovered.includes(id) ? "visible" : "hidden" }}>
+            <ClickableIcon
+              icon={faEdit}
+              onClick={() =>
+                dispatch(
+                  showModal({
+                    type: "EDIT_ANSWER",
+                    props: {
+                      puzzleId: row.values.id,
+                      answerId: id,
+                      text,
+                    },
+                  })
+                )
+              }
+            />{" "}
+            <ClickableIcon
+              icon={faTrashAlt}
+              onClick={() =>
+                dispatch(
+                  showModal({
+                    type: "DELETE_ANSWER",
+                    props: {
+                      puzzleId: row.values.id,
+                      answerId: id,
+                    },
+                  })
+                )
+              }
+            />
+            {" "}
+            <ClickableIcon
+              icon={faPlus}
+              onClick={() =>
+                dispatch(
+                  showModal({
+                    type: "SUBMIT_ANSWER",
+                    props: {
+                      puzzleId: row.values.id,
+                      puzzleName: row.values.name,
+                    },
+                  })
+                )
+              }
+            />
+          </div>
           <br />
-        </React.Fragment>
+        </div>
       ))}
-      <ClickableIcon
-        icon={faPlus}
-        onClick={() =>
-          dispatch(
-            showModal({
-              type: "SUBMIT_ANSWER",
-              props: {
-                puzzleId: row.values.id,
-                puzzleName: row.values.name,
-              },
-            })
-          )
-        }
-      />
     </>
   );
 }

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -30,7 +30,14 @@ export default function NameCell({ row, value }) {
   const toggleRowExpandedProps = useToggleRowExpandedProps(row);
   const dispatch = useDispatch();
   return (
-    <div onMouseEnter={() => { setUiHovered(true); }} onMouseLeave={() => { setUiHovered(false); }}>
+    <div
+      onMouseEnter={() => {
+        setUiHovered(true);
+      }}
+      onMouseLeave={() => {
+        setUiHovered(false);
+      }}
+    >
       {row.canExpand ? (
         <span {...toggleRowExpandedProps}>
           {row.isExpanded ? <IconChevronDown /> : <IconChevronRight />}
@@ -46,7 +53,12 @@ export default function NameCell({ row, value }) {
           <Badge variant="dark">META</Badge>{" "}
         </>
       ) : null}
-      <div style={{ display: "inline-block", visibility: uiHovered ? "visible" : "hidden" }}>
+      <div
+        style={{
+          display: "inline-block",
+          visibility: uiHovered ? "visible" : "hidden",
+        }}
+      >
         <ClickableIcon
           icon={faEdit}
           onClick={() =>

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -26,10 +26,11 @@ const useToggleRowExpandedProps = (row) => {
 
 export default function NameCell({ row, value }) {
   const { id: huntId } = useSelector((state) => state.hunt);
+  const [uiHovered, setUiHovered] = React.useState(false);
   const toggleRowExpandedProps = useToggleRowExpandedProps(row);
   const dispatch = useDispatch();
   return (
-    <>
+    <div onMouseEnter={() => { setUiHovered(true); }} onMouseLeave={() => { setUiHovered(false); }}>
       {row.canExpand ? (
         <span {...toggleRowExpandedProps}>
           {row.isExpanded ? <IconChevronDown /> : <IconChevronRight />}
@@ -45,39 +46,41 @@ export default function NameCell({ row, value }) {
           <Badge variant="dark">META</Badge>{" "}
         </>
       ) : null}
-      <ClickableIcon
-        icon={faEdit}
-        onClick={() =>
-          dispatch(
-            showModal({
-              type: "EDIT_PUZZLE",
-              props: {
-                huntId,
-                puzzleId: row.values.id,
-                name: row.values.name,
-                url: row.values.url,
-                isMeta: row.values.is_meta,
-                hasChannels: !!row.original.chat_room?.text_channel_url,
-              },
-            })
-          )
-        }
-      />{" "}
-      <ClickableIcon
-        icon={faTrashAlt}
-        onClick={() =>
-          dispatch(
-            showModal({
-              type: "DELETE_PUZZLE",
-              props: {
-                huntId,
-                puzzleId: row.values.id,
-                puzzleName: value,
-              },
-            })
-          )
-        }
-      />
-    </>
+      <div style={{ display: "inline-block", visibility: uiHovered ? "visible" : "hidden" }}>
+        <ClickableIcon
+          icon={faEdit}
+          onClick={() =>
+            dispatch(
+              showModal({
+                type: "EDIT_PUZZLE",
+                props: {
+                  huntId,
+                  puzzleId: row.values.id,
+                  name: row.values.name,
+                  url: row.values.url,
+                  isMeta: row.values.is_meta,
+                  hasChannels: !!row.original.chat_room?.text_channel_url,
+                },
+              })
+            )
+          }
+        />{" "}
+        <ClickableIcon
+          icon={faTrashAlt}
+          onClick={() =>
+            dispatch(
+              showModal({
+                type: "DELETE_PUZZLE",
+                props: {
+                  huntId,
+                  puzzleId: row.values.id,
+                  puzzleName: value,
+                },
+              })
+            )
+          }
+        />
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
Addresses #667 and #280 by making the editing buttons appear only on hover. This significantly reduces the UI clutter.


https://github.com/cardinalitypuzzles/cardboard/assets/342514/bb3419f4-89c1-4104-87fb-470d634aadc7

