### PR TITLE
Refresh tags upon adding a puzzle

### DIFF
--- a/hunts/src/AddPuzzleModal.js
+++ b/hunts/src/AddPuzzleModal.js
@@ -5,6 +5,7 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import { addPuzzle } from "./puzzlesSlice";
 import { hideModal } from "./modalSlice";
+import { fetchHunt } from "./huntSlice";
 
 function AddPuzzleModal({ huntId }) {
   const [name, setName] = React.useState("");
@@ -23,6 +24,8 @@ function AddPuzzleModal({ huntId }) {
         create_channels: createChannels,
       })
     ).finally(() => {
+      // Used to update hunt tags.
+      dispatch(fetchHunt(huntId));
       dispatch(hideModal());
     });
     return false;

--- a/hunts/src/EditPuzzleModal.js
+++ b/hunts/src/EditPuzzleModal.js
@@ -3,7 +3,7 @@ import { useDispatch } from "react-redux";
 import Modal from "react-bootstrap/Modal";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
-import { updatePuzzle } from "./puzzlesSlice";
+import { updatePuzzle, fetchPuzzles } from "./puzzlesSlice";
 import { hideModal } from "./modalSlice";
 import { fetchHunt } from "./huntSlice";
 
@@ -29,6 +29,8 @@ function EditPuzzleModal({ huntId, puzzleId, name, url, isMeta, hasChannels }) {
     ).finally(() => {
       // Used to update hunt tags.
       dispatch(fetchHunt(huntId));
+      dispatch(fetchPuzzles(huntId));
+
       dispatch(hideModal());
     });
     return false;

--- a/hunts/src/EditPuzzleModal.js
+++ b/hunts/src/EditPuzzleModal.js
@@ -5,6 +5,7 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import { updatePuzzle } from "./puzzlesSlice";
 import { hideModal } from "./modalSlice";
+import { fetchHunt } from "./huntSlice";
 
 function EditPuzzleModal({ huntId, puzzleId, name, url, isMeta, hasChannels }) {
   const [newName, setNewName] = React.useState(name);
@@ -26,6 +27,8 @@ function EditPuzzleModal({ huntId, puzzleId, name, url, isMeta, hasChannels }) {
         },
       })
     ).finally(() => {
+      // Used to update hunt tags.
+      dispatch(fetchHunt(huntId));
       dispatch(hideModal());
     });
     return false;

--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -49,16 +49,17 @@ export const HuntViewMain = (props) => {
 
   const dispatch = useDispatch();
 
-  const updatePuzzleData = () => {
+  const updatePuzzleAndHuntData = () => {
     dispatch(fetchPuzzles(props.huntId));
+    dispatch(fetchHunt(props.huntId));
   };
 
-  useInterval(updatePuzzleData, 10 * 1000);
+  useInterval(updatePuzzleAndHuntData, 10 * 1000);
 
   const ModalComponent = MODAL_COMPONENTS[modal.type];
   React.useEffect(() => {
     dispatch(fetchHunt(props.huntId));
-    updatePuzzleData();
+    updatePuzzleAndHuntData();
   }, [props.huntId]);
 
   React.useEffect(() => {


### PR DESCRIPTION
Address #672.

This re-fetches the hunt slice after adding a puzzle, so the new meta tag appears.