### PR TITLE
Switch to browser date and time pickers for hunt creation

### DIFF
--- a/hunts/forms.py
+++ b/hunts/forms.py
@@ -15,22 +15,30 @@ class HuntForm(forms.ModelForm):
     )
     start_time = forms.SplitDateTimeField(
         widget=forms.SplitDateTimeWidget(
-            date_attrs={"class": "form-control", "placeholder": "Start Date"},
+            date_attrs={
+                "class": "form-control",
+                "type": "date",
+            },
             time_attrs={
                 "class": "form-control",
-                "placeholder": "Start Time (ET, HH:MM, 24 hr)",
+                "type": "time",
             },
         ),
+        label="Start Time (ET)",
         required=False,
     )
     end_time = forms.SplitDateTimeField(
         widget=forms.SplitDateTimeWidget(
-            date_attrs={"class": "form-control", "placeholder": "End Date"},
+            date_attrs={
+                "class": "form-control",
+                "type": "date",
+            },
             time_attrs={
                 "class": "form-control",
-                "placeholder": "End Time (ET, HH:MM, 24 hr)",
+                "type": "time",
             },
         ),
+        label="End Time (ET)",
         required=False,
     )
 

--- a/hunts/templates/index.html
+++ b/hunts/templates/index.html
@@ -30,22 +30,7 @@
         <h2>Add New Hunt</h2>
         <form action="/hunts/" method="post">
             {% csrf_token %}
-            <div class="form-group">
-                {{ form.name }}
-            </div>
-            <div class="form-group">
-                {{ form.url }}
-            </div>
-            <div class="form-group">
-                {{ form.start_time }}
-            </div>
-            <div class="form-group">
-                {{ form.end_time }}
-            </div>
-            <div class="form-group">
-                {{ form.populate_tags.label_tag }}
-                {{ form.populate_tags }}
-            </div>
+            {{ form.as_p }}
             <button type="submit" class="btn btn-primary">Submit</button>
         </form>
         {% endif %}


### PR DESCRIPTION
Fixes #406

Makes creating a hunt slightly easier, also cleaning up the form code

Before:
<img width="1018" alt="image" src="https://github.com/cardinalitypuzzles/cardboard/assets/3475509/5184afdc-c12a-4731-ab0d-207796773fd9">

After:
<img width="1003" alt="image" src="https://github.com/cardinalitypuzzles/cardboard/assets/3475509/879318a6-3ec0-46f1-8ed5-8adc207c10e2">
