### PR TITLE
Merge tags column into puzzle name; bit of CSS

### DIFF
--- a/hunts/src/HuntViewMain.js
+++ b/hunts/src/HuntViewMain.js
@@ -73,7 +73,8 @@ export const HuntViewMain = (props) => {
       <SiteHeader />
       <div
         style={{
-          margin: "0 20px",
+          margin: "0px auto",
+          maxWidth: "1600px",
         }}
       >
         <Alert

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -29,7 +29,7 @@ export default function NameCell({ row, value }) {
   return (
     <div
       style={{
-	      paddingLeft: `${row.depth * 2}rem`,
+        paddingLeft: `${row.depth * 2}rem`,
       }}
     >
       <div
@@ -97,7 +97,7 @@ export default function NameCell({ row, value }) {
         </div>
       </div>
       <div>
-	      <TagCell row={row} />
+        <TagCell row={row} />
       </div>
     </div>
   );

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -10,8 +10,7 @@ import { IconChevronDown, IconChevronRight } from "@tabler/icons";
 
 const useToggleRowExpandedProps = (row) => {
   const dispatch = useDispatch();
-  const originalProps = row.getToggleRowExpandedProps({
-  });
+  const originalProps = row.getToggleRowExpandedProps({});
 
   return {
     ...originalProps,
@@ -30,7 +29,7 @@ export default function NameCell({ row, value }) {
   return (
     <div
       style={{
-	paddingLeft: `${row.depth * 2}rem`,
+	      paddingLeft: `${row.depth * 2}rem`,
       }}
     >
       <div
@@ -98,7 +97,7 @@ export default function NameCell({ row, value }) {
         </div>
       </div>
       <div>
-	<TagCell row={row} />
+	      <TagCell row={row} />
       </div>
     </div>
   );

--- a/hunts/src/NameCell.js
+++ b/hunts/src/NameCell.js
@@ -3,6 +3,7 @@ import Badge from "react-bootstrap/Badge";
 import { useSelector, useDispatch } from "react-redux";
 import { faEdit, faTrashAlt } from "@fortawesome/free-regular-svg-icons";
 import { showModal } from "./modalSlice";
+import TagCell from "./TagCell";
 import ClickableIcon from "./ClickableIcon";
 import { toggleCollapsed } from "./collapsedPuzzlesSlice";
 import { IconChevronDown, IconChevronRight } from "@tabler/icons";
@@ -10,9 +11,6 @@ import { IconChevronDown, IconChevronRight } from "@tabler/icons";
 const useToggleRowExpandedProps = (row) => {
   const dispatch = useDispatch();
   const originalProps = row.getToggleRowExpandedProps({
-    style: {
-      paddingLeft: `${row.depth * 2}rem`,
-    },
   });
 
   return {
@@ -31,67 +29,76 @@ export default function NameCell({ row, value }) {
   const dispatch = useDispatch();
   return (
     <div
-      onMouseEnter={() => {
-        setUiHovered(true);
-      }}
-      onMouseLeave={() => {
-        setUiHovered(false);
+      style={{
+	paddingLeft: `${row.depth * 2}rem`,
       }}
     >
-      {row.canExpand ? (
-        <span {...toggleRowExpandedProps}>
-          {row.isExpanded ? <IconChevronDown /> : <IconChevronRight />}
-          <b>{value}</b>
-        </span>
-      ) : (
-        <span style={{ paddingLeft: `${row.depth * 2}rem` }}>
-          <b>{value}</b>
-        </span>
-      )}{" "}
-      {row.values.is_meta ? (
-        <>
-          <Badge variant="dark">META</Badge>{" "}
-        </>
-      ) : null}
       <div
-        style={{
-          display: "inline-block",
-          visibility: uiHovered ? "visible" : "hidden",
+        onMouseEnter={() => {
+          setUiHovered(true);
+        }}
+        onMouseLeave={() => {
+          setUiHovered(false);
         }}
       >
-        <ClickableIcon
-          icon={faEdit}
-          onClick={() =>
-            dispatch(
-              showModal({
-                type: "EDIT_PUZZLE",
-                props: {
-                  huntId,
-                  puzzleId: row.values.id,
-                  name: row.values.name,
-                  url: row.values.url,
-                  isMeta: row.values.is_meta,
-                  hasChannels: !!row.original.chat_room?.text_channel_url,
-                },
-              })
-            )
-          }
-        />{" "}
-        <ClickableIcon
-          icon={faTrashAlt}
-          onClick={() =>
-            dispatch(
-              showModal({
-                type: "DELETE_PUZZLE",
-                props: {
-                  huntId,
-                  puzzleId: row.values.id,
-                  puzzleName: value,
-                },
-              })
-            )
-          }
-        />
+        {row.canExpand ? (
+          <span {...toggleRowExpandedProps}>
+            {row.isExpanded ? <IconChevronDown /> : <IconChevronRight />}
+            <b>{value}</b>
+          </span>
+        ) : (
+          <span>
+            <b>{value}</b>
+          </span>
+        )}{" "}
+        {row.values.is_meta ? (
+          <>
+            <Badge variant="dark">META</Badge>{" "}
+          </>
+        ) : null}
+        <div
+          style={{
+            display: "inline-block",
+            visibility: uiHovered ? "visible" : "hidden",
+          }}
+        >
+          <ClickableIcon
+            icon={faEdit}
+            onClick={() =>
+              dispatch(
+                showModal({
+                  type: "EDIT_PUZZLE",
+                  props: {
+                    huntId,
+                    puzzleId: row.values.id,
+                    name: row.values.name,
+                    url: row.values.url,
+                    isMeta: row.values.is_meta,
+                    hasChannels: !!row.original.chat_room?.text_channel_url,
+                  },
+                })
+              )
+            }
+          />{" "}
+          <ClickableIcon
+            icon={faTrashAlt}
+            onClick={() =>
+              dispatch(
+                showModal({
+                  type: "DELETE_PUZZLE",
+                  props: {
+                    huntId,
+                    puzzleId: row.values.id,
+                    puzzleName: value,
+                  },
+                })
+              )
+            }
+          />
+        </div>
+      </div>
+      <div>
+	<TagCell row={row} />
       </div>
     </div>
   );

--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -60,12 +60,8 @@ const TABLE_COLUMNS = [
     className: "col-1",
   },
   {
-    Header: "Tags/Metas",
-    id: "tags",
     accessor: (row) => row.tags.map(({ name }) => name).join(" "),
-    Cell: TagCell,
-    filter: "tagsFilter",
-    className: "col-3",
+    id: "tags",
   },
   {
     accessor: "is_meta",
@@ -163,7 +159,7 @@ export const PuzzleTable = React.memo(({ data, filterSolved, filterTags }) => {
       globalFilter: "globalFilter",
       autoResetFilters: false,
       initialState: {
-        hiddenColumns: ["is_meta", "id", "url"],
+        hiddenColumns: ["tags", "is_meta", "id", "url"],
         filters: [],
         // Apparently our patch of react-table introduces the 'collapsed'
         // object that has the opposite semantics of the 'expanded' API.

--- a/hunts/src/puzzle-table.js
+++ b/hunts/src/puzzle-table.js
@@ -62,6 +62,7 @@ const TABLE_COLUMNS = [
   {
     accessor: (row) => row.tags.map(({ name }) => name).join(" "),
     id: "tags",
+    filter: "tagsFilter",
   },
   {
     accessor: "is_meta",


### PR DESCRIPTION
tweaking the tags UI; in my experience, solvers usually use tags to figure out what puzzles they're interested in solving, so it's made sense for us (in Galactic's software) to put them under titles.

![image](https://github.com/cardinalitypuzzles/cardboard/assets/1885259/ff0c3b46-eafc-4798-9642-6d0b35eb9714)
