### PR TITLE
add backsolved option to SubmitAnswerModal

### DIFF
--- a/hunts/src/SubmitAnswerModal.js
+++ b/hunts/src/SubmitAnswerModal.js
@@ -20,7 +20,7 @@ function SubmitAnswerModal({ puzzleId, puzzleName }) {
           name: "Backsolved",
           color: "success",
         })
-      )
+      );
     }
     dispatch(
       addAnswer({
@@ -52,7 +52,7 @@ function SubmitAnswerModal({ puzzleId, puzzleName }) {
             label="backsolved"
             value={backsolved}
             onChange={(e) => {
-              e.target.checked ? setBacksolved(true) : setBacksolved(false)
+              e.target.checked ? setBacksolved(true) : setBacksolved(false);
             }}
           />
         </Modal.Body>

--- a/hunts/src/SubmitAnswerModal.js
+++ b/hunts/src/SubmitAnswerModal.js
@@ -3,14 +3,25 @@ import { useDispatch } from "react-redux";
 import Modal from "react-bootstrap/Modal";
 import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
-import { addAnswer } from "./puzzlesSlice";
+import { addAnswer, addPuzzleTag } from "./puzzlesSlice";
 import { hideModal } from "./modalSlice";
 
 function SubmitAnswerModal({ puzzleId, puzzleName }) {
   const [newAnswer, setNewAnswer] = React.useState("");
+  const [backsolved, setBacksolved] = React.useState(false);
+
   const dispatch = useDispatch();
   const onSubmit = (e) => {
     e.preventDefault();
+    if (backsolved) {
+      dispatch(
+        addPuzzleTag({
+          puzzleId,
+          name: "Backsolved",
+          color: "success",
+        })
+      )
+    }
     dispatch(
       addAnswer({
         puzzleId,
@@ -34,6 +45,15 @@ function SubmitAnswerModal({ puzzleId, puzzleName }) {
             value={newAnswer}
             autoFocus
             onChange={(e) => setNewAnswer(e.target.value)}
+          />
+          <Form.Check
+            type="checkbox"
+            defaultChecked={false}
+            label="backsolved"
+            value={backsolved}
+            onChange={(e) => {
+              e.target.checked ? setBacksolved(true) : setBacksolved(false)
+            }}
           />
         </Modal.Body>
         <Modal.Footer>


### PR DESCRIPTION
Adds a backsolved checkbox option to the submit answer modal.

I know this is simple, but I have no idea what I'm doing, so any feedback would be appreciated.

Addresses #675 .