### PR TITLE
reduce line height of table buttons

### DIFF
--- a/cardboard/static/style.css
+++ b/cardboard/static/style.css
@@ -103,3 +103,9 @@ body {
   max-width: 400px;
   overflow-wrap: anywhere;
 }
+
+.bootstrap button.cb-btn-compact,
+.bootstrap div.cb-btn-compact button {
+  padding: .15rem .7rem;
+  line-height: normal;
+}

--- a/hunts/src/AnswerCell.js
+++ b/hunts/src/AnswerCell.js
@@ -12,6 +12,7 @@ export default function AnswerCell({ row }) {
   if (row.original.guesses === undefined || row.original.guesses.length == 0) {
     return (
       <Button
+        className="cb-btn-compact"
         variant="outline-primary"
         onClick={() =>
           dispatch(

--- a/hunts/src/StatusCell.js
+++ b/hunts/src/StatusCell.js
@@ -17,6 +17,7 @@ export default function StatusCell({ row, value }) {
         id={`status-dropdown-${row.id}`}
         title={value}
         variant="outline-primary"
+        className="cb-btn-compact"
         onSelect={(status) => {
           dispatch(
             updatePuzzle({


### PR DESCRIPTION
The default Bootstrap button takes up a bit more vertical space than it needs to. This reclaims a little bit of it, for puzzles without long names and lots of tags (which should be most of them).

Could be argued that this makes the page look worse (happy to abandon), but I prefer it cause it's more compact + more of a 'Google spreadsheet' look.

(some of the puzzles take up more line height than you'd expect bc of the invisible wrench button)

**old**
![image](https://github.com/user-attachments/assets/572d487f-39e7-4494-a523-676348d4543d)


**new**
![image](https://github.com/user-attachments/assets/68b3c445-7676-4f8e-a1a7-028f8b239e0f)
