### PR TITLE
fix button compactness for dark mode

### DIFF
--- a/cardboard/static/style.css
+++ b/cardboard/static/style.css
@@ -105,7 +105,9 @@ body {
 }
 
 .bootstrap button.cb-btn-compact,
-.bootstrap div.cb-btn-compact button {
+.bootstrap div.cb-btn-compact button,
+.bootstrap-dark button.cb-btn-compact,
+.bootstrap-dark div.cb-btn-compact button {
   padding: .15rem .7rem;
   line-height: normal;
 }


### PR DESCRIPTION
`.bootstrap` isn't applied in dark mode apparently