### PR TITLE
remove poetry buildpack from docs

### DIFF
--- a/app.json
+++ b/app.json
@@ -5,9 +5,6 @@
             "url": "heroku/nodejs"
         },
         {
-            "url": "https://github.com/cardinalitypuzzles/python-poetry-buildpack.git"
-        },
-        {
             "url": "heroku/python"
         }
     ],

--- a/new-hunt-setup.md
+++ b/new-hunt-setup.md
@@ -47,11 +47,10 @@ Follow the Heroku documentation to [set up a Heroku app](https://devcenter.herok
 
 After creating a new application on Heroku, you will need to configure some resources, settings, and config variables.
 
-By default, Heroku may only set the heroku/nodejs buildpack when you deploy the first time, but Cardboard also requires the heroku/python buildpack and a buildpack specific to Python poetry. You can set the buildpacks on your application's settings page (`https://dashboard.heroku.com/apps/<YOUR_APP>/settings`) under the "Buildpacks" section. They should be set **in the following order**, mimicking the [app.json](https://github.com/cardinalitypuzzles/cardboard/blob/master/app.json) file in the repository:
+By default, Heroku may only set the heroku/nodejs buildpack when you deploy the first time, but Cardboard also requires the heroku/python buildpack. You can set the buildpacks on your application's settings page (`https://dashboard.heroku.com/apps/<YOUR_APP>/settings`) under the "Buildpacks" section. They should be set **in the following order**, mimicking the [app.json](https://github.com/cardinalitypuzzles/cardboard/blob/master/app.json) file in the repository:
 
   1. heroku/nodejs
-  2. https://github.com/cardinalitypuzzles/python-poetry-buildpack.git
-  3. heroku/python
+  2. heroku/python
 
 Alternatively, you can use the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli): run `heroku buildpacks` to check which buildpacks are installed, and if needed, run `heroku buildpacks:add` to add any missing ones. Make sure again that they are in the correct order.
 


### PR DESCRIPTION
Raised in #818, verified with our current live instance that the new heroku-provided buildpack just works.