### PR TITLE
only set ssl_cert_reqs for TLS/SSL-enabled redis

### DIFF
--- a/cardboard/settings.py
+++ b/cardboard/settings.py
@@ -337,14 +337,17 @@ LOGGING = {
 }
 
 # Redis settings
-
+REDIS_URL = os.environ.get("REDIS_URL", "redis://")
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": os.environ.get("REDIS_URL", "redis://"),
-        "OPTIONS": {"ssl_cert_reqs": None},
+        "LOCATION": REDIS_URL,
+        "OPTIONS": {},
     }
 }
+
+if "rediss" in REDIS_URL:
+    CACHES["default"]["OPTIONS"]["ssl_cert_reqs"] = None
 
 # Use 64 bit primary keys
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"


### PR DESCRIPTION
I was getting this error locally

```
celery-1  | [2024-12-25 04:35:59,412: ERROR/ForkPoolWorker-16] Task google_api_lib.tasks.update_active_users[1000ee76-95be-4f02-8e65-ca3c7d6efbdc] raised unexpected: TypeError("Connection.__init__() got an unexpected keyword argument 'ssl_cert_reqs'") 
```
I think because our Docker redis set up is not SSL enabled, but `ssl_cert_reqs` is needed for Heroku (#801)