### PR TITLE
Fix folder permissions check when link sharing is on

### DIFF
--- a/google_api_lib/tasks.py
+++ b/google_api_lib/tasks.py
@@ -683,7 +683,7 @@ def get_file_user_emails(self, file_id) -> List[str]:
     emails = set()
     for perm in permissions:
         if perm["id"] == "anyoneWithLink":
-            return None
+            continue
         email = perm["emailAddress"]
         emails.add(email)
         emails.add(email.lower())


### PR DESCRIPTION
This was previously because we used this for auth (so we treated link sharing on as a special case). Don't want this behavior now.