### PR TITLE
menu cleanup #1: tagging in tags column, metas in name column

### DIFF
--- a/hunts/src/EditPuzzleModal.tsx
+++ b/hunts/src/EditPuzzleModal.tsx
@@ -1,8 +1,10 @@
 import React, { FormEvent } from "react";
 import { Button, Form, Modal } from "react-bootstrap";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { selectHuntTags } from "./huntSlice";
 import { updatePuzzle } from "./puzzlesSlice";
 import { showModal, hideModal } from "./modalSlice";
+import EditableTagList from "./EditableTagList";
 
 import type { Dispatch } from "./store";
 import type { HuntId, PuzzleId } from "./types";
@@ -29,6 +31,9 @@ function EditPuzzleModal({
   const [newIsMeta, setNewIsMeta] = React.useState(isMeta);
   const [createChannels, setCreateChannels] = React.useState(hasChannels);
   const dispatch = useDispatch<Dispatch>();
+
+  const huntTags = useSelector(selectHuntTags);
+
   const onSubmit = (e: FormEvent) => {
     e.preventDefault();
     dispatch(
@@ -79,6 +84,11 @@ function EditPuzzleModal({
             id="is-meta-checkbox"
             checked={newIsMeta}
             onChange={(e: ChangeEvent) => setNewIsMeta(e.target.checked)}
+          />
+          <h5 style={{ textAlign: "center" }}>Parent Metas</h5>
+          <EditableTagList
+            puzzleId={puzzleId}
+            tags={huntTags.filter((tag) => tag.is_meta && tag.name != name)}
           />
           <Form.Check
             type="checkbox"

--- a/hunts/src/EditPuzzleModal.tsx
+++ b/hunts/src/EditPuzzleModal.tsx
@@ -1,8 +1,7 @@
 import React, { FormEvent } from "react";
 import { Button, Form, Modal } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
-import { selectHuntTags } from "./huntSlice";
-import { updatePuzzle } from "./puzzlesSlice";
+import { selectPuzzleTags, updatePuzzle } from "./puzzlesSlice";
 import { showModal, hideModal } from "./modalSlice";
 import EditableTagList from "./EditableTagList";
 
@@ -32,7 +31,7 @@ function EditPuzzleModal({
   const [createChannels, setCreateChannels] = React.useState(hasChannels);
   const dispatch = useDispatch<Dispatch>();
 
-  const huntTags = useSelector(selectHuntTags);
+  const tags = useSelector(selectPuzzleTags);
 
   const onSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -88,7 +87,7 @@ function EditPuzzleModal({
           <h5 style={{ textAlign: "center" }}>Parent Metas</h5>
           <EditableTagList
             puzzleId={puzzleId}
-            tags={huntTags.filter((tag) => tag.is_meta && tag.name != name)}
+            tags={tags.filter((tag) => tag.is_meta && tag.name != name)}
           />
           <Form.Check
             type="checkbox"

--- a/hunts/src/EditPuzzleTagsModal.tsx
+++ b/hunts/src/EditPuzzleTagsModal.tsx
@@ -38,12 +38,6 @@ function EditPuzzleTagsModal({
         <Modal.Title>Edit Tags for {puzzleName}</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <h5 style={{ textAlign: "center" }}>Metas</h5>
-        <EditableTagList
-          puzzleId={puzzleId}
-          tags={allTags.filter((tag) => tag.is_meta)}
-        />
-        <br />
         <h5 style={{ textAlign: "center" }}>Locations</h5>
         <EditableTagList
           puzzleId={puzzleId}

--- a/hunts/src/NameCell.tsx
+++ b/hunts/src/NameCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Badge, Popover, OverlayTrigger } from "react-bootstrap";
 import { useSelector, useDispatch } from "react-redux";
-import { faWrench, faTag } from "@fortawesome/free-solid-svg-icons";
+import { faWrench } from "@fortawesome/free-solid-svg-icons";
 import { showModal } from "./modalSlice";
 import ClickableIcon from "./ClickableIcon";
 import { toggleCollapsed } from "./collapsedPuzzlesSlice";
@@ -166,21 +166,6 @@ export default function NameCell({
                     url: row.values.url,
                     isMeta: row.values.is_meta,
                     hasChannels: !!row.original.chat_room?.text_channel_url,
-                  },
-                })
-              )
-            }
-          />{" "}
-          <ClickableIcon
-            icon={faTag}
-            onClick={() =>
-              dispatch(
-                showModal({
-                  type: "EDIT_TAGS",
-                  props: {
-                    huntId,
-                    puzzleId: row.values.id,
-                    puzzleName: row.values.name,
                   },
                 })
               )

--- a/hunts/src/TagCell.tsx
+++ b/hunts/src/TagCell.tsx
@@ -1,13 +1,17 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { showModal } from "./modalSlice";
+import { faTag } from "@fortawesome/free-solid-svg-icons";
 import { toggleFilterTag } from "./filterSlice";
 import TagPill from "./TagPill";
+import ClickableIcon from "./ClickableIcon";
 
-import type { Puzzle, Row } from "./types";
+import type { RootState } from "./store";
+import type { Hunt, Puzzle, Row } from "./types";
 
 function TagCell({ row }: { row: Row<Puzzle> }) {
   const dispatch = useDispatch();
+  const { id: huntId } = useSelector<RootState, Hunt>((state) => state.hunt);
   const puzzleId = row.original.id;
 
   const shouldShowMetaTags =
@@ -20,12 +24,28 @@ function TagCell({ row }: { row: Row<Puzzle> }) {
     <>
       {tagsToShow.map(({ name, color, id }) => (
         <TagPill
-          name={name}
-          color={color}
-          key={name}
-          onClick={() => dispatch(toggleFilterTag({ name, color, id }))}
+        name={name}
+        color={color}
+        key={name}
+        onClick={() => dispatch(toggleFilterTag({ name, color, id }))}
         />
       ))}{" "}
+
+      <ClickableIcon
+      icon={faTag}
+      onClick={() =>
+        dispatch(
+          showModal({
+            type: "EDIT_TAGS",
+            props: {
+              huntId,
+              puzzleId: row.values.id,
+              puzzleName: row.values.name,
+            },
+          })
+        )
+      }
+      />{" "}
     </>
   );
 }


### PR DESCRIPTION
move 'tag' button to tags column, which is more intuitive.

i didn't bother to add hover behavior to the tag button because i'm planning to remove these icons altogether, but am splitting the commit up a bit.

almost all of this is just c/p between different files, the work was basically already done for me

<img width="919" alt="image" src="https://github.com/user-attachments/assets/92bdff89-9632-44bd-8dc2-101ea7df4392" />

move meta-parenting stuff to the puzzle edit modal and remove it from the tag modal

<img width="512" alt="image" src="https://github.com/user-attachments/assets/6afed6fa-c5ae-4ce0-8c64-cd769bbd2e80" />

<img width="517" alt="image" src="https://github.com/user-attachments/assets/ef395840-ff04-430e-8295-0772afdd1e42" />
