### PR TITLE
two small UI fixes

### DIFF
--- a/hunts/src/AnswerCell.tsx
+++ b/hunts/src/AnswerCell.tsx
@@ -35,7 +35,7 @@ export default function AnswerCell({ row }: { row: Row<Puzzle> }) {
     );
   }
   return (
-    <>
+    <div style={{ padding: '3px 0px' }}>
       {row.original.guesses.map(({ id, text }) => (
         <div
           key={text}
@@ -101,6 +101,6 @@ export default function AnswerCell({ row }: { row: Row<Puzzle> }) {
           <br />
         </div>
       ))}
-    </>
+    </div>
   );
 }

--- a/hunts/src/TagCell.tsx
+++ b/hunts/src/TagCell.tsx
@@ -13,8 +13,8 @@ function TagCell({ row }: { row: Row<Puzzle> }) {
   const shouldShowMetaTags =
     row.original.tags.filter((t) => t.is_meta).length > 1;
   const tagsToShow = shouldShowMetaTags
-    ? row.original.tags
-    : row.original.tags.filter((t) => !t.is_meta);
+    ? row.original.tags.filter(t => t.name !== row.original.name)
+    : row.original.tags.filter((t) => !t.is_meta && t.name !== row.original.name);
 
   return (
     <>


### PR DESCRIPTION
- add padding to answer column (regression from #846)
- never show a puzzle's own meta tag (only affects nested metas, they're already hidden for non-nested)

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/bcdadbfb-dc0c-4743-b1b9-b1393941b8f2" />
