### PR TITLE
Move Links column closer to Name

### DIFF
--- a/hunts/src/puzzle-table.tsx
+++ b/hunts/src/puzzle-table.tsx
@@ -46,6 +46,11 @@ const TABLE_COLUMNS: TableColumnFormat[] = [
     className: "col-2",
   },
   {
+    Header: "Links",
+    Cell: LinkCell,
+    className: "col-1",
+  },
+  {
     Header: "Tags",
     id: "tags",
     Cell: TagCell,
@@ -86,11 +91,6 @@ const TABLE_COLUMNS: TableColumnFormat[] = [
     accessor: "status",
     Cell: StatusCell,
     filter: "solvedFilter",
-    className: "col-1",
-  },
-  {
-    Header: "Links",
-    Cell: LinkCell,
     className: "col-1",
   },
   {


### PR DESCRIPTION
For years, the Links column has been quite far from the puzzle Name (first column) - see image below. Most Cardboard users browse the list of puzzles and use these links to open Sheets or original puzzles. So it'd be more useful to place these links closer to the puzzle Name.

![image](https://github.com/user-attachments/assets/8bc0113e-e6e4-4224-8e04-640127058160)

After this change:

![image](https://github.com/user-attachments/assets/494a01a4-e09c-4c52-8507-b5ccdadca25f)
