### PR TITLE
Misc frontend tweaks & fixes

### DIFF
--- a/hunts/src/AddPuzzleModal.tsx
+++ b/hunts/src/AddPuzzleModal.tsx
@@ -86,7 +86,7 @@ function AddPuzzleModal({ huntId }: { huntId: HuntId }) {
           </Form.Group>
           <Form.Check
             type="checkbox"
-            label="Is meta"
+            label="This is a meta"
             id="is-meta-checkbox"
             checked={isMeta}
             onChange={(e: ChangeEvent) => setIsMeta(e.target.checked)}

--- a/hunts/src/EditPuzzleModal.tsx
+++ b/hunts/src/EditPuzzleModal.tsx
@@ -99,7 +99,7 @@ function EditPuzzleModal({
           <h5 style={{ textAlign: "center" }}>Parent Metas</h5>
           <EditableTagList
             puzzleId={puzzleId}
-            tags={tags.filter((tag) => tag.is_meta && tag.name != name)}
+            tags={meta_tags}
           />
           </>) : undefined}
         </Modal.Body>

--- a/hunts/src/EditPuzzleModal.tsx
+++ b/hunts/src/EditPuzzleModal.tsx
@@ -32,6 +32,7 @@ function EditPuzzleModal({
   const dispatch = useDispatch<Dispatch>();
 
   const tags = useSelector(selectPuzzleTags);
+  const meta_tags = tags.filter((tag) => tag.is_meta && tag.name != name);
 
   const onSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -79,15 +80,10 @@ function EditPuzzleModal({
           </Form.Group>
           <Form.Check
             type="checkbox"
-            label="Is meta"
+            label="This is a meta"
             id="is-meta-checkbox"
             checked={newIsMeta}
             onChange={(e: ChangeEvent) => setNewIsMeta(e.target.checked)}
-          />
-          <h5 style={{ textAlign: "center" }}>Parent Metas</h5>
-          <EditableTagList
-            puzzleId={puzzleId}
-            tags={tags.filter((tag) => tag.is_meta && tag.name != name)}
           />
           <Form.Check
             type="checkbox"
@@ -98,6 +94,14 @@ function EditPuzzleModal({
             // If channel is already created, disable its deletion
             disabled={hasChannels}
           />
+          {meta_tags.length > 0 ? (
+              <>
+          <h5 style={{ textAlign: "center" }}>Parent Metas</h5>
+          <EditableTagList
+            puzzleId={puzzleId}
+            tags={tags.filter((tag) => tag.is_meta && tag.name != name)}
+          />
+          </>) : undefined}
         </Modal.Body>
         <Modal.Footer>
           <Button

--- a/hunts/src/NotesCell.tsx
+++ b/hunts/src/NotesCell.tsx
@@ -1,26 +1,18 @@
 import React, { useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
+import { useDispatch } from "react-redux";
 import { editNotes } from "./puzzlesSlice";
 
-import type { Dispatch, RootState } from "./store";
-import type { Hunt, Row } from "./types";
+import type { Dispatch } from "./store";
+import type { Row } from "./types";
 
 export default function NotesCell({ row, value }: { row: Row; value: string }) {
-  const { id: huntId } = useSelector<RootState, Hunt>((state) => state.hunt);
-  const [uiHovered, setUiHovered] = useState(false);
   const [ editing, setEditing ] = useState(false);
   const [ editedNotesValue, setEditedNotesValue ] = useState(value);
   const dispatch = useDispatch<Dispatch>();
 
   return (
     <div
-    className="clickable-puzzle-cell"
-    onMouseEnter={() => {
-      setUiHovered(true);
-    }}
-    onMouseLeave={() => {
-      setUiHovered(false);
-    }}
+    className={!editing ? "clickable-puzzle-cell" : ""}
     onClick={() => {
       if (!editing) {
         setEditing(true);
@@ -33,7 +25,7 @@ export default function NotesCell({ row, value }: { row: Row; value: string }) {
         <textarea
           autoFocus
           value={editedNotesValue}
-          style={{ minHeight: '70px' }}
+          style={{ minHeight: '70px', width: '100%' }}
           onChange={(e) => {
             setEditedNotesValue(e.target.value);
           }}


### PR DESCRIPTION
    Fix Notes cell bugs

    The textarea was only taking up part of the width of the cell, and the
    yellow hover background would still appear while you were editing the note
    which was weird.


    Re-order Edit Puzzle modal

    This checkbox looked kinda bad underneath the meta tag section.
    Change the ugly "Is meta" language
    Hide the meta section when there are no metas to display
