### PR TITLE
Don't show meta tags by default for nested metas

### DIFF
--- a/hunts/src/TagCell.tsx
+++ b/hunts/src/TagCell.tsx
@@ -14,7 +14,7 @@ function TagCell({ row }: { row: Row<Puzzle> }) {
   const puzzleId = row.original.id;
 
   const shouldShowMetaTags =
-    row.original.tags.filter((t) => t.is_meta).length > 1;
+    row.original.tags.filter((t) => t.is_meta && t.name !== row.original.name).length > 1;
   const tagsToShow = shouldShowMetaTags
     ? row.original.tags.filter(t => t.name !== row.original.name)
     : row.original.tags.filter((t) => !t.is_meta && t.name !== row.original.name);


### PR DESCRIPTION
We made a change to not show meta tags if there's only 1, which reduces a lot of clutter. Feeder puzzles to a single meta don't have that meta's tag by default already.

However, nested meta puzzles would still show the tag for their parent meta. I think those are unnecessary as well (it's conveyed by the table indentaiton) so this commit hides them for the case of a single parent meta. If there are multiple parent metas then the tags are shown again.

Examples of meta tags from last year's hunt that would be hidden by this change:
<img width="992" alt="image" src="https://github.com/user-attachments/assets/e10c85aa-85d4-4a8c-9bef-bb8d4e53640a" />
